### PR TITLE
feat: Implement admin password reset functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ Data/
 ## Ignore artwork directory
 artwork/
 */artwork/
+IMPLEMENTATION_PLAN_USER_LIST.md
+.claude/CLAUDE.md
+.github/workflows/docker-build.yml.bak

--- a/src/Audiarr.Api/Endpoints/AuthEndpoints.cs
+++ b/src/Audiarr.Api/Endpoints/AuthEndpoints.cs
@@ -157,12 +157,20 @@ public static class AuthEndpoints
                 return Results.BadRequest("Current password is incorrect");
             }
             
+            // Get the user from the current context to ensure it's tracked
+            var userToUpdate = await context.Users.FindAsync(validUser.Id);
+            if (userToUpdate == null)
+            {
+                return Results.BadRequest("User not found");
+            }
+            
             // Update password
-            validUser.PasswordHash = BCrypt.Net.BCrypt.HashPassword(request.NewPassword);
+            userToUpdate.PasswordHash = BCrypt.Net.BCrypt.HashPassword(request.NewPassword);
+            context.Update(userToUpdate);  // Mark entity as modified since we're using NoTracking globally
             await context.SaveChangesAsync();
             
             // Revoke all sessions for security
-            await authService.RevokeAllUserSessionsAsync(validUser.Id);
+            await authService.RevokeAllUserSessionsAsync(userToUpdate.Id);
             
             return Results.Ok(new { message = "Password changed successfully. Please login again." });
         })

--- a/src/Audiarr.Api/Endpoints/UserEndpoints.cs
+++ b/src/Audiarr.Api/Endpoints/UserEndpoints.cs
@@ -51,6 +51,15 @@ public static class UserEndpoints
             .WithDescription("Checks if an email address is unique and available for use.")
             .Produces<bool>(200);
 
+        group.MapPost("/{userId}/reset-password", ResetUserPassword)
+            .WithName("ResetUserPassword")
+            .WithSummary("Reset a user's password")
+            .WithDescription("Allows admins to reset passwords for other users. Cannot reset own password.")
+            .Produces<ResetPasswordResponse>(200)
+            .Produces<ProblemDetails>(400)
+            .Produces(401)
+            .Produces(403);
+
         return app;
     }
 
@@ -187,5 +196,41 @@ public static class UserEndpoints
     {
         var isAvailable = await userService.IsEmailUniqueAsync(email);
         return TypedResults.Ok(isAvailable);
+    }
+
+    private static async Task<Results<Ok<ResetPasswordResponse>, ProblemHttpResult>> ResetUserPassword(
+        IUserManagementService userService,
+        HttpContext httpContext,
+        string userId,
+        ResetPasswordRequest request)
+    {
+        var adminUserId = httpContext.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        if (string.IsNullOrEmpty(adminUserId))
+        {
+            return TypedResults.Problem(
+                detail: "Admin user ID not found in token",
+                statusCode: StatusCodes.Status401Unauthorized
+            );
+        }
+
+        try
+        {
+            var result = await userService.ResetPasswordAsync(userId, adminUserId, request);
+            return TypedResults.Ok(result);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return TypedResults.Problem(
+                detail: ex.Message,
+                statusCode: StatusCodes.Status400BadRequest
+            );
+        }
+        catch (ArgumentException ex)
+        {
+            return TypedResults.Problem(
+                detail: ex.Message,
+                statusCode: StatusCodes.Status400BadRequest
+            );
+        }
     }
 }

--- a/src/Audiarr.Api/Pages/Admin/Settings.razor
+++ b/src/Audiarr.Api/Pages/Admin/Settings.razor
@@ -182,7 +182,7 @@
             var authState = await AuthStateProvider.GetAuthenticationStateAsync();
             if (authState.User.Identity?.IsAuthenticated == true)
             {
-                var token = await LocalStorage.GetAsync<string>("authToken");
+                var token = await LocalStorage.GetAsync<string>("accessToken");
                 if (token.Success && !string.IsNullOrEmpty(token.Value))
                 {
                     Http.DefaultRequestHeaders.Authorization = 
@@ -354,7 +354,7 @@
 
         try
         {
-            var token = await LocalStorage.GetAsync<string>("authToken");
+            var token = await LocalStorage.GetAsync<string>("accessToken");
             if (!token.Success || string.IsNullOrEmpty(token.Value))
             {
                 errorMessage = "Authentication token not found. Please login again.";
@@ -374,7 +374,7 @@
                 
                 // Clear stored token and redirect to login after 2 seconds
                 await Task.Delay(2000);
-                await LocalStorage.DeleteAsync("authToken");
+                await LocalStorage.DeleteAsync("accessToken");
                 await LocalStorage.DeleteAsync("refreshToken");
                 
                 if (AuthStateProvider is BlazorAuthStateProvider blazorAuthProvider)

--- a/src/Audiarr.Api/Pages/Admin/Users.razor
+++ b/src/Audiarr.Api/Pages/Admin/Users.razor
@@ -9,6 +9,9 @@
 @inject IUserManagementService UserService
 @inject NavigationManager Navigation
 @inject AuthenticationStateProvider AuthStateProvider
+@inject Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage.ProtectedLocalStorage LocalStorage
+@inject IHttpClientFactory HttpClientFactory
+@inject IJSRuntime JSRuntime
 
 <PageTitle>Users - Audiarr Admin</PageTitle>
 
@@ -83,6 +86,7 @@ else
                             <span class="sort-indicator">@(sortOrder == "asc" ? "▲" : "▼")</span>
                         }
                     </th>
+                    <th class="text-center">Actions</th>
                 </tr>
             </thead>
             <tbody>
@@ -136,6 +140,18 @@ else
                             <span title="@user.CreatedAt.ToString("yyyy-MM-dd HH:mm:ss")">
                                 @user.CreatedAt.ToString("yyyy-MM-dd")
                             </span>
+                        </td>
+                        <td class="text-center">
+                            @if (user.Username != currentUsername)
+                            {
+                                <button class="btn btn-sm btn-outline-warning" @onclick="() => OpenResetPasswordModal(user)" title="Reset Password">
+                                    <i class="bi bi-key"></i>
+                                </button>
+                            }
+                            else
+                            {
+                                <span class="text-muted" title="Cannot reset your own password here">-</span>
+                            }
                         </td>
                     </tr>
                 }
@@ -287,6 +303,109 @@ else
     </div>
 }
 
+@if (showResetPasswordModal)
+{
+    <div class="modal d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Reset Password for @resetPasswordUser?.Username</h5>
+                    <button type="button" class="btn-close" @onclick="CloseResetPasswordModal"></button>
+                </div>
+                <div class="modal-body">
+                    @if (!string.IsNullOrEmpty(resetPasswordError))
+                    {
+                        <div class="alert alert-danger" role="alert">
+                            @resetPasswordError
+                        </div>
+                    }
+                    @if (!string.IsNullOrEmpty(generatedPassword))
+                    {
+                        <div class="alert alert-success" role="alert">
+                            <h6 class="alert-heading">Password Reset Successfully!</h6>
+                            <p>The new password for <strong>@resetPasswordUser?.Username</strong> is:</p>
+                            <div class="input-group mb-2">
+                                <input type="text" class="form-control font-monospace" value="@generatedPassword" readonly />
+                                <button class="btn btn-outline-secondary" type="button" @onclick="CopyPasswordToClipboard" title="Copy to clipboard">
+                                    <i class="bi bi-clipboard"></i> @(passwordCopied ? "Copied!" : "Copy")
+                                </button>
+                            </div>
+                            <hr>
+                            <p class="mb-0 small">Make sure to securely share this password with the user. They will be able to change it after logging in.</p>
+                        </div>
+                    }
+                    else
+                    {
+                        <form @onsubmit="ResetPassword" @onsubmit:preventDefault="true">
+                            <div class="mb-3">
+                                <label class="form-label">Password Reset Method</label>
+                                <div class="form-check">
+                                    <input class="form-check-input" type="radio" name="resetMethod" id="generateRandom" 
+                                           value="true" checked="@resetPasswordRequest.GenerateRandom" 
+                                           @onchange="() => SetPasswordResetMethod(true)" />
+                                    <label class="form-check-label" for="generateRandom">
+                                        Generate secure random password (recommended)
+                                    </label>
+                                </div>
+                                <div class="form-check">
+                                    <input class="form-check-input" type="radio" name="resetMethod" id="manualPassword" 
+                                           value="false" checked="@(!resetPasswordRequest.GenerateRandom)" 
+                                           @onchange="() => SetPasswordResetMethod(false)" />
+                                    <label class="form-check-label" for="manualPassword">
+                                        Set manual password
+                                    </label>
+                                </div>
+                            </div>
+                            
+                            @if (!resetPasswordRequest.GenerateRandom)
+                            {
+                                <div class="mb-3">
+                                    <label for="manualPasswordInput" class="form-label">New Password</label>
+                                    <input type="password" class="form-control" id="manualPasswordInput" 
+                                           @bind="resetPasswordRequest.ManualPassword" 
+                                           placeholder="Enter new password" required />
+                                    <small class="form-text text-muted">Minimum 8 characters</small>
+                                </div>
+                            }
+                            
+                            <div class="alert alert-warning" role="alert">
+                                <i class="bi bi-exclamation-triangle"></i> This action will:
+                                <ul class="mb-0 mt-2">
+                                    <li>Immediately change the user's password</li>
+                                    <li>Log out the user from all sessions</li>
+                                    <li>Create an audit log entry</li>
+                                </ul>
+                            </div>
+                        </form>
+                    }
+                </div>
+                <div class="modal-footer">
+                    @if (string.IsNullOrEmpty(generatedPassword))
+                    {
+                        <button type="button" class="btn btn-secondary" @onclick="CloseResetPasswordModal">Cancel</button>
+                        <button type="button" class="btn btn-warning" @onclick="ResetPassword" 
+                                disabled="@(isResettingPassword || (!resetPasswordRequest.GenerateRandom && string.IsNullOrWhiteSpace(resetPasswordRequest.ManualPassword)))">
+                            @if (isResettingPassword)
+                            {
+                                <span class="spinner-border spinner-border-sm me-2" role="status"></span>
+                                <span>Resetting...</span>
+                            }
+                            else
+                            {
+                                <span><i class="bi bi-key"></i> Reset Password</span>
+                            }
+                        </button>
+                    }
+                    else
+                    {
+                        <button type="button" class="btn btn-primary" @onclick="CloseResetPasswordModal">Close</button>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
 <style>
     .sortable {
         cursor: pointer;
@@ -330,6 +449,15 @@ else
     private string emailError = "";
     private string passwordStrength = "Weak";
     private List<string> passwordValidationErrors = new();
+    
+    // Reset Password Modal
+    private bool showResetPasswordModal = false;
+    private UserListDto? resetPasswordUser = null;
+    private ResetPasswordRequest resetPasswordRequest = new();
+    private bool isResettingPassword = false;
+    private string resetPasswordError = "";
+    private string generatedPassword = "";
+    private bool passwordCopied = false;
     
     private class CreateUserModel
     {
@@ -717,5 +845,120 @@ else
 
         ValidatePassword();
         return !passwordValidationErrors.Any();
+    }
+
+    // Reset Password Methods
+    private void OpenResetPasswordModal(UserListDto user)
+    {
+        resetPasswordUser = user;
+        resetPasswordRequest = new ResetPasswordRequest();
+        generatedPassword = "";
+        resetPasswordError = "";
+        passwordCopied = false;
+        showResetPasswordModal = true;
+    }
+
+    private void CloseResetPasswordModal()
+    {
+        showResetPasswordModal = false;
+        resetPasswordUser = null;
+        generatedPassword = "";
+        resetPasswordError = "";
+        passwordCopied = false;
+        resetPasswordRequest = new ResetPasswordRequest();
+    }
+
+    private void SetPasswordResetMethod(bool generateRandom)
+    {
+        resetPasswordRequest = new ResetPasswordRequest
+        {
+            GenerateRandom = generateRandom,
+            ManualPassword = generateRandom ? null : ""
+        };
+    }
+
+    private async Task ResetPassword()
+    {
+        if (resetPasswordUser == null || isResettingPassword)
+            return;
+
+        isResettingPassword = true;
+        resetPasswordError = "";
+        StateHasChanged();
+
+        try
+        {
+            var tokenResult = await LocalStorage.GetAsync<string>("accessToken");
+            var token = tokenResult.Success ? tokenResult.Value : null;
+            if (string.IsNullOrEmpty(token))
+            {
+                resetPasswordError = "Authentication token not found";
+                return;
+            }
+
+            using var client = HttpClientFactory.CreateClient();
+            client.DefaultRequestHeaders.Authorization = 
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+
+            var response = await client.PostAsJsonAsync(
+                $"http://localhost:5209/api/v2/users/{resetPasswordUser.Id}/reset-password", 
+                resetPasswordRequest);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var result = await response.Content.ReadFromJsonAsync<ResetPasswordResponse>();
+                if (result != null)
+                {
+                    generatedPassword = result.NewPassword;
+                    await LoadUsers(); // Refresh the list
+                }
+            }
+            else
+            {
+                var problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+                resetPasswordError = problemDetails?.Detail ?? "Failed to reset password";
+            }
+        }
+        catch (Exception ex)
+        {
+            resetPasswordError = $"Error: {ex.Message}";
+        }
+        finally
+        {
+            isResettingPassword = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task CopyPasswordToClipboard()
+    {
+        if (!string.IsNullOrEmpty(generatedPassword))
+        {
+            await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", generatedPassword);
+            passwordCopied = true;
+            StateHasChanged();
+            
+            // Reset the "Copied!" text after 2 seconds
+            await Task.Delay(2000);
+            passwordCopied = false;
+            StateHasChanged();
+        }
+    }
+
+    private class ResetPasswordResponse
+    {
+        public string NewPassword { get; set; } = "";
+        public string Method { get; set; } = "";
+    }
+
+    private class ResetPasswordRequest  
+    {
+        public bool GenerateRandom { get; set; } = true;
+        public string? ManualPassword { get; set; }
+    }
+
+    private class ProblemDetails
+    {
+        public string? Detail { get; set; }
     }
 }

--- a/src/Audiarr.Api/Program.cs
+++ b/src/Audiarr.Api/Program.cs
@@ -107,11 +107,47 @@ builder.Services.AddSingleton<ScannerBackgroundService>();
 builder.Services.AddHostedService(provider => provider.GetRequiredService<ScannerBackgroundService>());
 
 // Configure SQLite database
-var dataPath = builder.Environment.IsDevelopment() 
-    ? Path.Combine(Directory.GetCurrentDirectory(), "Data")
-    : "/data";
+string dataPath;
+
+if (!builder.Environment.IsDevelopment())
+{
+    // Production/Docker environment - use /data volume
+    dataPath = "/data";
+}
+else
+{
+    // Development environment - find project root and use Data folder there
+    var currentDirectory = Directory.GetCurrentDirectory();
+    var projectRoot = currentDirectory;
+    
+    // Walk up the directory tree to find the solution root
+    while (!File.Exists(Path.Combine(projectRoot, "Audiarr.sln")) && projectRoot != Path.GetPathRoot(projectRoot))
+    {
+        var parent = Directory.GetParent(projectRoot);
+        if (parent == null) break;
+        projectRoot = parent.FullName;
+    }
+    
+    // If we couldn't find the solution file, use current directory
+    if (!File.Exists(Path.Combine(projectRoot, "Audiarr.sln")))
+    {
+        projectRoot = currentDirectory;
+    }
+    
+    dataPath = Path.Combine(projectRoot, "Data");
+}
+
+// Allow override via environment variable
+var envDataPath = Environment.GetEnvironmentVariable("AUDIARR_DATA_PATH");
+if (!string.IsNullOrEmpty(envDataPath))
+{
+    dataPath = envDataPath;
+    Console.WriteLine($"Using data path from environment variable: {dataPath}");
+}
+
 Directory.CreateDirectory(dataPath);
 var connectionString = $"Data Source={Path.Combine(dataPath, "audiarr.db")}";
+Console.WriteLine($"Database location: {Path.Combine(dataPath, "audiarr.db")}");
 
 builder.Services.AddDbContext<AudiarrContext>(options =>
 {
@@ -150,6 +186,9 @@ builder.Services.AddCors(options =>
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
 builder.Services.AddSignalR();
+
+// Add HttpClient factory for dependency injection
+builder.Services.AddHttpClient();
 
 // Add HttpClient for Blazor components
 builder.Services.AddScoped<HttpClient>(sp =>

--- a/src/Audiarr.Core/DTOs/UserManagementDTOs.cs
+++ b/src/Audiarr.Core/DTOs/UserManagementDTOs.cs
@@ -40,3 +40,13 @@ public record CreateUserResponse(
     string Role,
     DateTime CreatedAt
 );
+
+public record ResetPasswordRequest(
+    bool GenerateRandom = true,
+    string? ManualPassword = null
+);
+
+public record ResetPasswordResponse(
+    string NewPassword,
+    string Method // "generated" or "manual"
+);

--- a/src/Audiarr.Core/Entities/AuditLog.cs
+++ b/src/Audiarr.Core/Entities/AuditLog.cs
@@ -1,0 +1,15 @@
+namespace Audiarr.Core.Entities;
+
+public class AuditLog
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string Action { get; set; } = string.Empty;
+    public string? TargetUserId { get; set; }
+    public string PerformedByUserId { get; set; } = string.Empty;
+    public string? Details { get; set; }
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+    
+    // Navigation properties
+    public virtual User? TargetUser { get; set; }
+    public virtual User PerformedByUser { get; set; } = null!;
+}

--- a/src/Audiarr.Data/AudiarrContextFactory.cs
+++ b/src/Audiarr.Data/AudiarrContextFactory.cs
@@ -10,8 +10,31 @@ public class AudiarrContextFactory : IDesignTimeDbContextFactory<AudiarrContext>
     {
         var optionsBuilder = new DbContextOptionsBuilder<AudiarrContext>();
         
-        // Use a default connection string for design-time operations
-        var connectionString = "Data Source=audiarr.db";
+        // Find the project root directory (where the .sln file is)
+        var currentDirectory = Directory.GetCurrentDirectory();
+        var projectRoot = currentDirectory;
+        
+        // Walk up the directory tree to find the solution root
+        while (!File.Exists(Path.Combine(projectRoot, "Audiarr.sln")) && projectRoot != Path.GetPathRoot(projectRoot))
+        {
+            var parent = Directory.GetParent(projectRoot);
+            if (parent == null) break;
+            projectRoot = parent.FullName;
+        }
+        
+        // If we couldn't find the solution file, use current directory
+        if (!File.Exists(Path.Combine(projectRoot, "Audiarr.sln")))
+        {
+            projectRoot = currentDirectory;
+        }
+        
+        // Create Data directory at project root if it doesn't exist
+        var dataPath = Path.Combine(projectRoot, "Data");
+        Directory.CreateDirectory(dataPath);
+        
+        // Use consistent database path
+        var connectionString = $"Data Source={Path.Combine(dataPath, "audiarr.db")}";
+        Console.WriteLine($"Design-time DbContext using database at: {Path.Combine(dataPath, "audiarr.db")}");
         
         optionsBuilder.UseSqlite(connectionString);
 

--- a/src/Audiarr.Data/Context/AudiarrContext.cs
+++ b/src/Audiarr.Data/Context/AudiarrContext.cs
@@ -28,6 +28,7 @@ public class AudiarrContext : DbContext
     public DbSet<Playlist> Playlists { get; set; } = null!;
     public DbSet<PlaylistTrack> PlaylistTracks { get; set; } = null!;
     public DbSet<Session> Sessions { get; set; } = null!;
+    public DbSet<AuditLog> AuditLogs { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -134,6 +135,27 @@ public class AudiarrContext : DbContext
                 .WithMany()
                 .HasForeignKey(e => e.UserId)
                 .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // Configure AuditLog entity
+        modelBuilder.Entity<AuditLog>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.HasIndex(e => e.Timestamp);
+            entity.HasIndex(e => e.PerformedByUserId);
+            entity.HasIndex(e => e.TargetUserId);
+            entity.Property(e => e.Action).IsRequired().HasMaxLength(100);
+            entity.Property(e => e.Details).HasMaxLength(1000);
+            
+            entity.HasOne(e => e.PerformedByUser)
+                .WithMany()
+                .HasForeignKey(e => e.PerformedByUserId)
+                .OnDelete(DeleteBehavior.Restrict);
+                
+            entity.HasOne(e => e.TargetUser)
+                .WithMany()
+                .HasForeignKey(e => e.TargetUserId)
+                .OnDelete(DeleteBehavior.SetNull);
         });
 
         // Seed admin user with fixed values to prevent migration changes

--- a/src/Audiarr.Data/Migrations/20250908230959_AddAuditLogTable.Designer.cs
+++ b/src/Audiarr.Data/Migrations/20250908230959_AddAuditLogTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Audiarr.Data.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Audiarr.Data.Migrations
 {
     [DbContext(typeof(AudiarrContext))]
-    partial class AudiarrContextModelSnapshot : ModelSnapshot
+    [Migration("20250908230959_AddAuditLogTable")]
+    partial class AddAuditLogTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.0");

--- a/src/Audiarr.Data/Migrations/20250908230959_AddAuditLogTable.cs
+++ b/src/Audiarr.Data/Migrations/20250908230959_AddAuditLogTable.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Audiarr.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAuditLogTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AuditLogs",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "TEXT", nullable: false),
+                    Action = table.Column<string>(type: "TEXT", maxLength: 100, nullable: false),
+                    TargetUserId = table.Column<string>(type: "TEXT", nullable: true),
+                    PerformedByUserId = table.Column<string>(type: "TEXT", nullable: false),
+                    Details = table.Column<string>(type: "TEXT", maxLength: 1000, nullable: true),
+                    Timestamp = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AuditLogs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AuditLogs_Users_PerformedByUserId",
+                        column: x => x.PerformedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_AuditLogs_Users_TargetUserId",
+                        column: x => x.TargetUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AuditLogs_PerformedByUserId",
+                table: "AuditLogs",
+                column: "PerformedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AuditLogs_TargetUserId",
+                table: "AuditLogs",
+                column: "TargetUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AuditLogs_Timestamp",
+                table: "AuditLogs",
+                column: "Timestamp");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AuditLogs");
+        }
+    }
+}

--- a/src/Audiarr.Services/Users/UserManagementService.cs
+++ b/src/Audiarr.Services/Users/UserManagementService.cs
@@ -1,4 +1,6 @@
 using System.Linq.Expressions;
+using System.Security.Cryptography;
+using System.Text;
 using Audiarr.Core.DTOs;
 using Audiarr.Core.Entities;
 using Audiarr.Data.Context;
@@ -15,6 +17,7 @@ public interface IUserManagementService
     Task<CreateUserResponse> CreateUserAsync(CreateUserRequest request);
     Task<bool> IsUsernameUniqueAsync(string username, string? excludeUserId = null);
     Task<bool> IsEmailUniqueAsync(string email, string? excludeUserId = null);
+    Task<ResetPasswordResponse> ResetPasswordAsync(string targetUserId, string performedByUserId, ResetPasswordRequest request);
 }
 
 public class UserManagementService : IUserManagementService
@@ -194,5 +197,123 @@ public class UserManagementService : IUserManagementService
         }
 
         return !await query.AnyAsync();
+    }
+
+    public async Task<ResetPasswordResponse> ResetPasswordAsync(string targetUserId, string performedByUserId, ResetPasswordRequest request)
+    {
+        _logger.LogInformation("Resetting password for user {TargetUserId} by admin {AdminUserId}", targetUserId, performedByUserId);
+
+        // Check if target user exists
+        var targetUser = await _context.Users.FindAsync(targetUserId);
+        if (targetUser == null)
+        {
+            throw new InvalidOperationException($"User with ID '{targetUserId}' not found");
+        }
+
+        // Prevent admin from resetting their own password through this method
+        if (targetUserId == performedByUserId)
+        {
+            throw new InvalidOperationException("Admins cannot reset their own password through this method. Please use the password change feature.");
+        }
+
+        string newPassword;
+        string method;
+
+        if (request.GenerateRandom)
+        {
+            // Generate a secure random password
+            newPassword = GenerateSecurePassword();
+            method = "generated";
+        }
+        else
+        {
+            if (string.IsNullOrWhiteSpace(request.ManualPassword))
+            {
+                throw new ArgumentException("Manual password cannot be empty when not generating a random password");
+            }
+
+            if (request.ManualPassword.Length < 8)
+            {
+                throw new ArgumentException("Password must be at least 8 characters long");
+            }
+
+            newPassword = request.ManualPassword;
+            method = "manual";
+        }
+
+        // Hash the new password
+        targetUser.PasswordHash = BCrypt.Net.BCrypt.HashPassword(newPassword);
+        targetUser.UpdatedAt = DateTime.UtcNow;
+
+        // Invalidate all existing sessions for the user
+        var userSessions = await _context.Sessions
+            .Where(s => s.UserId == targetUserId)
+            .ToListAsync();
+
+        if (userSessions.Any())
+        {
+            _context.Sessions.RemoveRange(userSessions);
+            _logger.LogInformation("Invalidated {SessionCount} sessions for user {UserId}", userSessions.Count, targetUserId);
+        }
+
+        // Create audit log entry
+        var auditLog = new AuditLog
+        {
+            Action = "PasswordReset",
+            TargetUserId = targetUserId,
+            PerformedByUserId = performedByUserId,
+            Details = $"Password reset using {method} method",
+            Timestamp = DateTime.UtcNow
+        };
+
+        _context.AuditLogs.Add(auditLog);
+
+        // Save all changes
+        await _context.SaveChangesAsync();
+
+        // Invalidate cache since user data has changed
+        InvalidateCache();
+
+        _logger.LogInformation("Successfully reset password for user {TargetUserId} using {Method} method", targetUserId, method);
+
+        return new ResetPasswordResponse(newPassword, method);
+    }
+
+    private static string GenerateSecurePassword(int length = 12)
+    {
+        const string upperCase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        const string lowerCase = "abcdefghijklmnopqrstuvwxyz";
+        const string digits = "0123456789";
+        const string special = "!@#$%^&*()_+-=[]{}|;:,.<>?";
+        const string allChars = upperCase + lowerCase + digits + special;
+
+        var password = new char[length];
+        var randomBytes = new byte[length * 4];
+        
+        using (var rng = RandomNumberGenerator.Create())
+        {
+            rng.GetBytes(randomBytes);
+        }
+
+        // Ensure at least one character from each category
+        password[0] = upperCase[Math.Abs(BitConverter.ToInt32(randomBytes, 0)) % upperCase.Length];
+        password[1] = lowerCase[Math.Abs(BitConverter.ToInt32(randomBytes, 4)) % lowerCase.Length];
+        password[2] = digits[Math.Abs(BitConverter.ToInt32(randomBytes, 8)) % digits.Length];
+        password[3] = special[Math.Abs(BitConverter.ToInt32(randomBytes, 12)) % special.Length];
+
+        // Fill the rest with random characters from all categories
+        for (int i = 4; i < length; i++)
+        {
+            password[i] = allChars[Math.Abs(BitConverter.ToInt32(randomBytes, i * 4) % allChars.Length)];
+        }
+
+        // Shuffle the password to avoid predictable patterns
+        for (int i = length - 1; i > 0; i--)
+        {
+            int j = Math.Abs(BitConverter.ToInt32(randomBytes, i * 4) % (i + 1));
+            (password[i], password[j]) = (password[j], password[i]);
+        }
+
+        return new string(password);
     }
 }


### PR DESCRIPTION
## Summary
Closes #35 

Implements complete admin password reset functionality with security features and audit logging.

## Features Implemented
- ✅ Reset password button in Users page for admins
- ✅ Modal dialog with confirmation before reset
- ✅ Two reset methods: random generation (12 chars) and manual entry
- ✅ Secure password generation with mixed character types
- ✅ Copy to clipboard functionality
- ✅ Session invalidation after password reset
- ✅ Audit logging system to track admin actions
- ✅ Prevention of self-password reset
- ✅ Success/error notifications

## Bug Fixes
- Fixed authentication token storage inconsistency (authToken vs accessToken)
- Fixed password changes not saving due to NoTracking DbContext configuration  
- Fixed missing IHttpClientFactory dependency injection
- Improved database path resolution for Docker and local environments

## Testing
- Tested password reset with both random and manual methods
- Verified session invalidation works correctly
- Confirmed audit logs are created
- Tested self-reset prevention
- Verified clipboard copy functionality