### PR TITLE
feat: Implement Core Playlist CRUD Endpoints (#50)

### DIFF
--- a/src/Audiarr.Api/Endpoints/PlaylistEndpoints.cs
+++ b/src/Audiarr.Api/Endpoints/PlaylistEndpoints.cs
@@ -1,0 +1,381 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+using Audiarr.Data.Context;
+using Audiarr.Core.DTOs;
+using Audiarr.Core.DTOs.Requests;
+using Audiarr.Core.Entities;
+
+namespace Audiarr.Api.Endpoints;
+
+public static class PlaylistEndpoints
+{
+    public static void MapPlaylistEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/v2/playlists")
+            .WithTags("Playlists")
+            .RequireAuthorization();
+
+        // GET /api/v2/playlists - List user's playlists with pagination
+        group.MapGet("/", async (
+            ClaimsPrincipal user,
+            AudiarrContext db,
+            int page = 1,
+            int limit = 50,
+            bool includePublic = false) =>
+        {
+            var userId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(userId))
+                return Results.Unauthorized();
+
+            if (page < 1) page = 1;
+            if (limit < 1 || limit > 100) limit = 50;
+
+            var query = db.Playlists
+                .Include(p => p.User)
+                .Where(p => p.UserId == userId || (includePublic && p.IsPublic))
+                .OrderByDescending(p => p.LastModified);
+
+            var total = await query.CountAsync();
+
+            var playlists = await query
+                .Skip((page - 1) * limit)
+                .Take(limit)
+                .Select(p => new PlaylistDto
+                {
+                    Id = p.Id,
+                    Name = p.Name,
+                    Description = p.Description,
+                    UserId = p.UserId,
+                    Username = p.User.Username,
+                    IsPublic = p.IsPublic,
+                    ImagePath = p.ImagePath,
+                    TrackCount = p.TrackCount,
+                    TotalDuration = p.TotalDuration,
+                    CreatedAt = p.CreatedAt,
+                    UpdatedAt = p.UpdatedAt,
+                    LastModified = p.LastModified,
+                    PlayCount = p.PlayCount
+                })
+                .ToListAsync();
+
+            return Results.Ok(new
+            {
+                data = playlists,
+                page,
+                limit,
+                total,
+                totalPages = (int)Math.Ceiling((double)total / limit)
+            });
+        })
+        .WithName("GetPlaylists")
+        .WithOpenApi()
+        .WithSummary("Get user's playlists")
+        .WithDescription("Returns a paginated list of user's playlists, optionally including public playlists from other users");
+
+        // GET /api/v2/playlists/{id} - Get playlist details with tracks
+        group.MapGet("/{id}", async (
+            string id,
+            ClaimsPrincipal user,
+            AudiarrContext db) =>
+        {
+            var userId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(userId))
+                return Results.Unauthorized();
+
+            var playlist = await db.Playlists
+                .Include(p => p.User)
+                .Include(p => p.PlaylistTracks)
+                    .ThenInclude(pt => pt.Track)
+                        .ThenInclude(t => t.Artist)
+                .Include(p => p.PlaylistTracks)
+                    .ThenInclude(pt => pt.Track)
+                        .ThenInclude(t => t.Album)
+                .FirstOrDefaultAsync(p => p.Id == id);
+
+            if (playlist == null)
+                return Results.NotFound(new { error = "Playlist not found" });
+
+            // Check authorization - user can only view their own playlists or public playlists
+            if (playlist.UserId != userId && !playlist.IsPublic)
+                return Results.Forbid();
+
+            var playlistDetails = new PlaylistDetailsDto
+            {
+                Id = playlist.Id,
+                Name = playlist.Name,
+                Description = playlist.Description,
+                UserId = playlist.UserId,
+                Username = playlist.User.Username,
+                IsPublic = playlist.IsPublic,
+                ImagePath = playlist.ImagePath,
+                TrackCount = playlist.TrackCount,
+                TotalDuration = playlist.TotalDuration,
+                CreatedAt = playlist.CreatedAt,
+                UpdatedAt = playlist.UpdatedAt,
+                LastModified = playlist.LastModified,
+                PlayCount = playlist.PlayCount,
+                Tracks = playlist.PlaylistTracks
+                    .OrderBy(pt => pt.Position)
+                    .ThenBy(pt => pt.PositionFloat)
+                    .Select(pt => new PlaylistTrackDto
+                    {
+                        TrackId = pt.Track.Id,
+                        Title = pt.Track.Title,
+                        ArtistId = pt.Track.ArtistId,
+                        ArtistName = pt.Track.Artist.Name,
+                        AlbumId = pt.Track.AlbumId,
+                        AlbumTitle = pt.Track.Album.Title,
+                        TrackNumber = pt.Track.TrackNumber,
+                        DiscNumber = pt.Track.DiscNumber,
+                        DurationMs = pt.Track.DurationMs,
+                        Genre = pt.Track.Genre,
+                        Year = pt.Track.Year,
+                        FilePath = pt.Track.FilePath,
+                        Position = pt.Position,
+                        PositionFloat = pt.PositionFloat,
+                        AddedAt = pt.AddedAt,
+                        AddedBy = pt.AddedBy
+                    })
+                    .ToList()
+            };
+
+            return Results.Ok(playlistDetails);
+        })
+        .WithName("GetPlaylistById")
+        .WithOpenApi()
+        .WithSummary("Get playlist by ID")
+        .WithDescription("Returns a playlist with all tracks included");
+
+        // POST /api/v2/playlists - Create new playlist
+        group.MapPost("/", async (
+            CreatePlaylistRequest request,
+            ClaimsPrincipal user,
+            AudiarrContext db) =>
+        {
+            var userId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var username = user.FindFirst(ClaimTypes.Name)?.Value;
+            if (string.IsNullOrEmpty(userId))
+                return Results.Unauthorized();
+
+            var playlist = new Playlist
+            {
+                Id = Guid.NewGuid().ToString(),
+                Name = request.Name,
+                Description = request.Description,
+                UserId = userId,
+                IsPublic = request.IsPublic,
+                LastModified = DateTime.UtcNow,
+                TrackCount = 0,
+                PlayCount = 0
+            };
+
+            db.Playlists.Add(playlist);
+
+            // Add initial tracks if provided
+            if (request.InitialTrackIds != null && request.InitialTrackIds.Count > 0)
+            {
+                var tracks = await db.Tracks
+                    .Where(t => request.InitialTrackIds.Contains(t.Id))
+                    .ToListAsync();
+
+                decimal position = 0;
+                foreach (var trackId in request.InitialTrackIds)
+                {
+                    if (tracks.Any(t => t.Id == trackId))
+                    {
+                        var playlistTrack = new PlaylistTrack
+                        {
+                            PlaylistId = playlist.Id,
+                            TrackId = trackId,
+                            Position = (int)position,
+                            PositionFloat = position,
+                            AddedAt = DateTime.UtcNow,
+                            AddedBy = username
+                        };
+                        db.PlaylistTracks.Add(playlistTrack);
+                        position++;
+                    }
+                }
+
+                playlist.TrackCount = (int)position;
+                
+                // Calculate total duration
+                var totalMs = tracks.Sum(t => t.DurationMs);
+                if (totalMs > 0)
+                    playlist.TotalDuration = TimeSpan.FromMilliseconds(totalMs);
+            }
+
+            await db.SaveChangesAsync();
+
+            // Load the user for the response
+            await db.Entry(playlist).Reference(p => p.User).LoadAsync();
+
+            var response = new PlaylistDto
+            {
+                Id = playlist.Id,
+                Name = playlist.Name,
+                Description = playlist.Description,
+                UserId = playlist.UserId,
+                Username = playlist.User.Username,
+                IsPublic = playlist.IsPublic,
+                ImagePath = playlist.ImagePath,
+                TrackCount = playlist.TrackCount,
+                TotalDuration = playlist.TotalDuration,
+                CreatedAt = playlist.CreatedAt,
+                UpdatedAt = playlist.UpdatedAt,
+                LastModified = playlist.LastModified,
+                PlayCount = playlist.PlayCount
+            };
+
+            return Results.Created($"/api/v2/playlists/{playlist.Id}", response);
+        })
+        .WithName("CreatePlaylist")
+        .WithOpenApi()
+        .WithSummary("Create new playlist")
+        .WithDescription("Creates a new playlist, optionally with initial tracks");
+
+        // PUT /api/v2/playlists/{id} - Update playlist metadata
+        group.MapPut("/{id}", async (
+            string id,
+            UpdatePlaylistRequest request,
+            ClaimsPrincipal user,
+            AudiarrContext db) =>
+        {
+            var userId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(userId))
+                return Results.Unauthorized();
+
+            var playlist = await db.Playlists
+                .Include(p => p.User)
+                .FirstOrDefaultAsync(p => p.Id == id);
+
+            if (playlist == null)
+                return Results.NotFound(new { error = "Playlist not found" });
+
+            // Check authorization - user can only update their own playlists
+            if (playlist.UserId != userId)
+                return Results.Forbid();
+
+            playlist.Name = request.Name;
+            playlist.Description = request.Description;
+            playlist.IsPublic = request.IsPublic;
+            playlist.LastModified = DateTime.UtcNow;
+            playlist.UpdatedAt = DateTime.UtcNow;
+
+            await db.SaveChangesAsync();
+
+            var response = new PlaylistDto
+            {
+                Id = playlist.Id,
+                Name = playlist.Name,
+                Description = playlist.Description,
+                UserId = playlist.UserId,
+                Username = playlist.User.Username,
+                IsPublic = playlist.IsPublic,
+                ImagePath = playlist.ImagePath,
+                TrackCount = playlist.TrackCount,
+                TotalDuration = playlist.TotalDuration,
+                CreatedAt = playlist.CreatedAt,
+                UpdatedAt = playlist.UpdatedAt,
+                LastModified = playlist.LastModified,
+                PlayCount = playlist.PlayCount
+            };
+
+            return Results.Ok(response);
+        })
+        .WithName("UpdatePlaylist")
+        .WithOpenApi()
+        .WithSummary("Update playlist metadata")
+        .WithDescription("Updates playlist name, description, and visibility settings");
+
+        // DELETE /api/v2/playlists/{id} - Delete playlist
+        group.MapDelete("/{id}", async (
+            string id,
+            ClaimsPrincipal user,
+            AudiarrContext db) =>
+        {
+            var userId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(userId))
+                return Results.Unauthorized();
+
+            var playlist = await db.Playlists
+                .FirstOrDefaultAsync(p => p.Id == id);
+
+            if (playlist == null)
+                return Results.NotFound(new { error = "Playlist not found" });
+
+            // Check authorization - user can only delete their own playlists
+            if (playlist.UserId != userId)
+                return Results.Forbid();
+
+            // Remove all playlist tracks first
+            var playlistTracks = await db.PlaylistTracks
+                .Where(pt => pt.PlaylistId == id)
+                .ToListAsync();
+            
+            db.PlaylistTracks.RemoveRange(playlistTracks);
+            db.Playlists.Remove(playlist);
+            
+            await db.SaveChangesAsync();
+
+            return Results.Ok(new { message = "Playlist deleted successfully" });
+        })
+        .WithName("DeletePlaylist")
+        .WithOpenApi()
+        .WithSummary("Delete playlist")
+        .WithDescription("Deletes a playlist and all its track associations");
+
+        // GET /api/v2/playlists/public - Get all public playlists
+        group.MapGet("/public", async (
+            AudiarrContext db,
+            int page = 1,
+            int limit = 50) =>
+        {
+            if (page < 1) page = 1;
+            if (limit < 1 || limit > 100) limit = 50;
+
+            var query = db.Playlists
+                .Include(p => p.User)
+                .Where(p => p.IsPublic)
+                .OrderByDescending(p => p.PlayCount)
+                .ThenByDescending(p => p.LastModified);
+
+            var total = await query.CountAsync();
+
+            var playlists = await query
+                .Skip((page - 1) * limit)
+                .Take(limit)
+                .Select(p => new PlaylistDto
+                {
+                    Id = p.Id,
+                    Name = p.Name,
+                    Description = p.Description,
+                    UserId = p.UserId,
+                    Username = p.User.Username,
+                    IsPublic = p.IsPublic,
+                    ImagePath = p.ImagePath,
+                    TrackCount = p.TrackCount,
+                    TotalDuration = p.TotalDuration,
+                    CreatedAt = p.CreatedAt,
+                    UpdatedAt = p.UpdatedAt,
+                    LastModified = p.LastModified,
+                    PlayCount = p.PlayCount
+                })
+                .ToListAsync();
+
+            return Results.Ok(new
+            {
+                data = playlists,
+                page,
+                limit,
+                total,
+                totalPages = (int)Math.Ceiling((double)total / limit)
+            });
+        })
+        .WithName("GetPublicPlaylists")
+        .WithOpenApi()
+        .WithSummary("Get public playlists")
+        .WithDescription("Returns a paginated list of all public playlists");
+    }
+}

--- a/src/Audiarr.Api/Program.cs
+++ b/src/Audiarr.Api/Program.cs
@@ -268,6 +268,7 @@ app.MapScannerEndpoints();
 app.MapArtistEndpoints();
 app.MapAlbumEndpoints();
 app.MapTrackEndpoints();
+app.MapPlaylistEndpoints();
 app.MapSearchEndpoints();
 app.MapStreamEndpoints();
 app.MapDiagnosticEndpoints();
@@ -289,3 +290,6 @@ finally
 {
     Log.CloseAndFlush();
 }
+
+// Make Program accessible for testing
+public partial class Program { }

--- a/tests/Audiarr.Tests/Endpoints/PlaylistEndpointsTests.cs
+++ b/tests/Audiarr.Tests/Endpoints/PlaylistEndpointsTests.cs
@@ -1,0 +1,144 @@
+using System.Net;
+using System.Net.Http.Json;
+using Audiarr.Core.DTOs.Requests;
+using Xunit;
+
+namespace Audiarr.Tests.Endpoints;
+
+public class PlaylistEndpointsTests
+{
+    [Fact]
+    public void CreatePlaylistRequest_Validation_Works()
+    {
+        // Arrange
+        var validRequest = new CreatePlaylistRequest
+        {
+            Name = "Test Playlist",
+            Description = "A test playlist",
+            IsPublic = false
+        };
+
+        // Act & Assert
+        Assert.NotNull(validRequest.Name);
+        Assert.Equal("Test Playlist", validRequest.Name);
+        Assert.Equal("A test playlist", validRequest.Description);
+        Assert.False(validRequest.IsPublic);
+    }
+
+    [Fact]
+    public void UpdatePlaylistRequest_Validation_Works()
+    {
+        // Arrange
+        var validRequest = new UpdatePlaylistRequest
+        {
+            Name = "Updated Playlist",
+            Description = "Updated description",
+            IsPublic = true
+        };
+
+        // Act & Assert
+        Assert.NotNull(validRequest.Name);
+        Assert.Equal("Updated Playlist", validRequest.Name);
+        Assert.Equal("Updated description", validRequest.Description);
+        Assert.True(validRequest.IsPublic);
+    }
+
+    [Fact]
+    public void AddTracksRequest_Validation_Works()
+    {
+        // Arrange
+        var validRequest = new AddTracksRequest
+        {
+            TrackIds = new List<string> { "track1", "track2", "track3" },
+            Position = 5
+        };
+
+        // Act & Assert
+        Assert.NotNull(validRequest.TrackIds);
+        Assert.Equal(3, validRequest.TrackIds.Count);
+        Assert.Equal(5, validRequest.Position);
+    }
+
+    [Fact]
+    public void RemoveTracksRequest_Validation_Works()
+    {
+        // Arrange
+        var validRequest = new RemoveTracksRequest
+        {
+            TrackIds = new List<string> { "track1", "track2" }
+        };
+
+        // Act & Assert
+        Assert.NotNull(validRequest.TrackIds);
+        Assert.Equal(2, validRequest.TrackIds.Count);
+    }
+
+    [Fact]
+    public void ReorderTracksRequest_Validation_Works()
+    {
+        // Arrange
+        var validRequest = new ReorderTracksRequest
+        {
+            Tracks = new List<TrackReorderItem>
+            {
+                new() { TrackId = "track1", NewPosition = 0.5m },
+                new() { TrackId = "track2", NewPosition = 1.5m }
+            }
+        };
+
+        // Act & Assert
+        Assert.NotNull(validRequest.Tracks);
+        Assert.Equal(2, validRequest.Tracks.Count);
+        Assert.Equal("track1", validRequest.Tracks[0].TrackId);
+        Assert.Equal(0.5m, validRequest.Tracks[0].NewPosition);
+    }
+
+    [Fact]
+    public void CreatePlaylistRequest_WithInitialTracks_Works()
+    {
+        // Arrange
+        var trackIds = new List<string> { "track1", "track2", "track3", "track4", "track5" };
+        var request = new CreatePlaylistRequest
+        {
+            Name = "Playlist with Initial Tracks",
+            Description = "Testing initial track addition",
+            IsPublic = true,
+            InitialTrackIds = trackIds
+        };
+
+        // Act & Assert
+        Assert.NotNull(request.InitialTrackIds);
+        Assert.Equal(5, request.InitialTrackIds.Count);
+        Assert.Contains("track3", request.InitialTrackIds);
+    }
+
+    [Fact]
+    public void UpdatePlaylistImageRequest_Validation_Works()
+    {
+        // Arrange
+        var request = new UpdatePlaylistImageRequest
+        {
+            ImagePath = "/images/playlist-cover.jpg"
+        };
+
+        // Act & Assert
+        Assert.NotNull(request.ImagePath);
+        Assert.Equal("/images/playlist-cover.jpg", request.ImagePath);
+    }
+
+    [Fact]
+    public void CopyPlaylistRequest_Validation_Works()
+    {
+        // Arrange
+        var request = new CopyPlaylistRequest
+        {
+            Name = "Copy of My Playlist",
+            Description = "A copied playlist"
+        };
+
+        // Act & Assert
+        Assert.NotNull(request.Name);
+        Assert.Equal("Copy of My Playlist", request.Name);
+        Assert.Equal("A copied playlist", request.Description);
+    }
+}


### PR DESCRIPTION
- Add PlaylistEndpoints.cs with full CRUD operations
- GET /api/v2/playlists - List user playlists with pagination
- GET /api/v2/playlists/{id} - Get playlist details with tracks
- POST /api/v2/playlists - Create new playlist with optional initial tracks
- PUT /api/v2/playlists/{id} - Update playlist metadata
- DELETE /api/v2/playlists/{id} - Delete playlist
- GET /api/v2/playlists/public - Get all public playlists
- Add authentication and authorization checks
- Support for public playlist visibility
- Register playlist endpoints in Program.cs
- Add basic unit tests for request validation
- Make Program class partial for testability