### PR TITLE
feat: Create PlaybackQueue entity with JSON storage (#55)

### DIFF
--- a/src/Audiarr.Core/Entities/PlaybackQueue.cs
+++ b/src/Audiarr.Core/Entities/PlaybackQueue.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Audiarr.Core.Entities;
+
+public class PlaybackQueue : BaseEntity
+{
+    public required string UserId { get; set; }
+    
+    // JSON serialized queue state
+    public string QueueStateJson { get; set; } = "{}";
+    
+    // Quick access properties stored as columns for querying
+    public int CurrentIndex { get; set; } = 0;
+    public string? CurrentTrackId { get; set; }
+    public RepeatMode RepeatMode { get; set; } = RepeatMode.None;
+    public bool IsShuffled { get; set; } = false;
+    public DateTime LastActivity { get; set; } = DateTime.UtcNow;
+    public int Version { get; set; } = 1;
+    
+    // Navigation property
+    public virtual User User { get; set; } = null!;
+    public virtual Track? CurrentTrack { get; set; }
+    
+    // Non-mapped property for queue state
+    private QueueState? _queueState;
+    
+    [JsonIgnore]
+    public QueueState QueueState
+    {
+        get
+        {
+            if (_queueState == null && !string.IsNullOrEmpty(QueueStateJson))
+            {
+                _queueState = JsonSerializer.Deserialize<QueueState>(QueueStateJson) ?? new QueueState();
+            }
+            return _queueState ?? new QueueState();
+        }
+        set
+        {
+            _queueState = value;
+            QueueStateJson = JsonSerializer.Serialize(value, new JsonSerializerOptions 
+            { 
+                WriteIndented = false,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            });
+        }
+    }
+    
+    // Helper methods
+    public void UpdateActivity()
+    {
+        LastActivity = DateTime.UtcNow;
+        UpdatedAt = DateTime.UtcNow;
+    }
+    
+    public bool HasTracks()
+    {
+        return QueueState.TrackIds?.Any() == true;
+    }
+    
+    public int GetTrackCount()
+    {
+        return QueueState.TrackIds?.Count ?? 0;
+    }
+    
+    public void ClearQueue()
+    {
+        QueueState = new QueueState();
+        CurrentIndex = 0;
+        CurrentTrackId = null;
+        IsShuffled = false;
+        UpdateActivity();
+    }
+    
+    public void SetTracks(List<string> trackIds, bool shuffle = false)
+    {
+        if (trackIds.Count > 1000)
+        {
+            throw new ArgumentException("Queue cannot exceed 1000 tracks");
+        }
+        
+        var state = new QueueState
+        {
+            TrackIds = trackIds,
+            OriginalTrackIds = new List<string>(trackIds)
+        };
+        
+        if (shuffle)
+        {
+            state.ShuffledTrackIds = ShuffleList(trackIds);
+            IsShuffled = true;
+        }
+        
+        QueueState = state;
+        CurrentIndex = 0;
+        CurrentTrackId = trackIds.FirstOrDefault();
+        UpdateActivity();
+    }
+    
+    private List<string> ShuffleList(List<string> list)
+    {
+        var shuffled = new List<string>(list);
+        var random = new Random();
+        
+        for (int i = shuffled.Count - 1; i > 0; i--)
+        {
+            int j = random.Next(i + 1);
+            (shuffled[i], shuffled[j]) = (shuffled[j], shuffled[i]);
+        }
+        
+        return shuffled;
+    }
+}
+
+public enum RepeatMode
+{
+    None = 0,
+    One = 1,
+    All = 2
+}
+
+public class QueueState
+{
+    public List<string>? TrackIds { get; set; }
+    public List<string>? OriginalTrackIds { get; set; }
+    public List<string>? ShuffledTrackIds { get; set; }
+    public Dictionary<string, object>? Metadata { get; set; }
+    
+    public QueueState()
+    {
+        TrackIds = new List<string>();
+        OriginalTrackIds = new List<string>();
+    }
+}

--- a/src/Audiarr.Data/Context/AudiarrContext.cs
+++ b/src/Audiarr.Data/Context/AudiarrContext.cs
@@ -27,6 +27,7 @@ public class AudiarrContext : DbContext
     public DbSet<Track> Tracks { get; set; } = null!;
     public DbSet<Playlist> Playlists { get; set; } = null!;
     public DbSet<PlaylistTrack> PlaylistTracks { get; set; } = null!;
+    public DbSet<PlaybackQueue> PlaybackQueues { get; set; } = null!;
     public DbSet<Session> Sessions { get; set; } = null!;
     public DbSet<AuditLog> AuditLogs { get; set; } = null!;
 
@@ -151,6 +152,52 @@ public class AudiarrContext : DbContext
                 .WithMany(t => t.PlaylistTracks)
                 .HasForeignKey(e => e.TrackId)
                 .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // Configure PlaybackQueue entity
+        modelBuilder.Entity<PlaybackQueue>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            
+            // Ensure one queue per user
+            entity.HasIndex(e => e.UserId).IsUnique();
+            
+            // Indexes for performance
+            entity.HasIndex(e => e.LastActivity);
+            entity.HasIndex(e => e.CurrentTrackId);
+            
+            // Property configurations
+            entity.Property(e => e.QueueStateJson)
+                .IsRequired()
+                .HasDefaultValue("{}")
+                .HasColumnType("TEXT");
+            
+            entity.Property(e => e.RepeatMode)
+                .HasConversion<int>()
+                .HasDefaultValue(RepeatMode.None);
+            
+            entity.Property(e => e.IsShuffled)
+                .HasDefaultValue(false);
+            
+            entity.Property(e => e.CurrentIndex)
+                .HasDefaultValue(0);
+            
+            entity.Property(e => e.Version)
+                .HasDefaultValue(1);
+            
+            // Ignore the non-mapped QueueState property
+            entity.Ignore(e => e.QueueState);
+            
+            // Relationships
+            entity.HasOne(e => e.User)
+                .WithOne()
+                .HasForeignKey<PlaybackQueue>(e => e.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+            
+            entity.HasOne(e => e.CurrentTrack)
+                .WithMany()
+                .HasForeignKey(e => e.CurrentTrackId)
+                .OnDelete(DeleteBehavior.SetNull);
         });
 
         // Configure Session entity

--- a/src/Audiarr.Data/Migrations/20250910204808_AddPlaybackQueueEntity.Designer.cs
+++ b/src/Audiarr.Data/Migrations/20250910204808_AddPlaybackQueueEntity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Audiarr.Data.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Audiarr.Data.Migrations
 {
     [DbContext(typeof(AudiarrContext))]
-    partial class AudiarrContextModelSnapshot : ModelSnapshot
+    [Migration("20250910204808_AddPlaybackQueueEntity")]
+    partial class AddPlaybackQueueEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.0");

--- a/src/Audiarr.Data/Migrations/20250910204808_AddPlaybackQueueEntity.cs
+++ b/src/Audiarr.Data/Migrations/20250910204808_AddPlaybackQueueEntity.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Audiarr.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlaybackQueueEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PlaybackQueues",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "TEXT", nullable: false),
+                    UserId = table.Column<string>(type: "TEXT", nullable: false),
+                    QueueStateJson = table.Column<string>(type: "TEXT", nullable: false, defaultValue: "{}"),
+                    CurrentIndex = table.Column<int>(type: "INTEGER", nullable: false, defaultValue: 0),
+                    CurrentTrackId = table.Column<string>(type: "TEXT", nullable: true),
+                    RepeatMode = table.Column<int>(type: "INTEGER", nullable: false, defaultValue: 0),
+                    IsShuffled = table.Column<bool>(type: "INTEGER", nullable: false, defaultValue: false),
+                    LastActivity = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    Version = table.Column<int>(type: "INTEGER", nullable: false, defaultValue: 1),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PlaybackQueues", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PlaybackQueues_Tracks_CurrentTrackId",
+                        column: x => x.CurrentTrackId,
+                        principalTable: "Tracks",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_PlaybackQueues_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlaybackQueues_CurrentTrackId",
+                table: "PlaybackQueues",
+                column: "CurrentTrackId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlaybackQueues_LastActivity",
+                table: "PlaybackQueues",
+                column: "LastActivity");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlaybackQueues_UserId",
+                table: "PlaybackQueues",
+                column: "UserId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PlaybackQueues");
+        }
+    }
+}


### PR DESCRIPTION
- Add PlaybackQueue entity with flexible JSON queue state storage
- Support one queue per user with unique constraint
- Include repeat mode (None/One/All) and shuffle state tracking
- Track current position and playing track
- Add last activity timestamp for cleanup operations
- Implement helper methods for queue management
- Enforce 1000 track maximum limit
- Add version field for future migrations
- Configure entity relationships and indexes in DbContext
- Create and apply database migration