### PR TITLE
feat: Create Queue DTOs and Request Models (#56)

### DIFF
--- a/src/Audiarr.Core/DTOs/QueueItemDto.cs
+++ b/src/Audiarr.Core/DTOs/QueueItemDto.cs
@@ -1,0 +1,10 @@
+namespace Audiarr.Core.DTOs;
+
+public class QueueItemDto
+{
+    public int Index { get; set; }
+    public string TrackId { get; set; } = string.Empty;
+    public TrackDto Track { get; set; } = null!;
+    public DateTime AddedAt { get; set; }
+    public string? Source { get; set; }
+}

--- a/src/Audiarr.Core/DTOs/QueueStateDto.cs
+++ b/src/Audiarr.Core/DTOs/QueueStateDto.cs
@@ -1,0 +1,18 @@
+using Audiarr.Core.Entities;
+
+namespace Audiarr.Core.DTOs;
+
+public class QueueStateDto
+{
+    public string QueueId { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+    public List<string> TrackIds { get; set; } = new();
+    public string? CurrentTrackId { get; set; }
+    public int CurrentIndex { get; set; }
+    public RepeatMode RepeatMode { get; set; }
+    public bool IsShuffled { get; set; }
+    public int TotalTracks { get; set; }
+    public string? QueueSource { get; set; }
+    public DateTime LastActivity { get; set; }
+    public int Version { get; set; }
+}

--- a/src/Audiarr.Core/DTOs/Requests/QueueRequests.cs
+++ b/src/Audiarr.Core/DTOs/Requests/QueueRequests.cs
@@ -1,0 +1,56 @@
+using System.ComponentModel.DataAnnotations;
+using Audiarr.Core.Entities;
+
+namespace Audiarr.Core.DTOs.Requests;
+
+public record AddToQueueRequest
+{
+    [Required]
+    [MinLength(1, ErrorMessage = "At least one track must be provided")]
+    [MaxLength(100, ErrorMessage = "Cannot add more than 100 tracks at once")]
+    public required List<string> TrackIds { get; init; }
+    
+    [StringLength(100)]
+    public string? Source { get; init; }
+    
+    public bool PlayNext { get; init; } = false;
+}
+
+public record UpdateQueueRequest
+{
+    public RepeatMode? RepeatMode { get; init; }
+    
+    public bool? IsShuffled { get; init; }
+    
+    [Range(0, int.MaxValue, ErrorMessage = "Current index must be non-negative")]
+    public int? CurrentIndex { get; init; }
+}
+
+public record ReorderQueueRequest
+{
+    [Required]
+    public required string TrackId { get; init; }
+    
+    [Required]
+    [Range(0, int.MaxValue, ErrorMessage = "New index must be non-negative")]
+    public required int NewIndex { get; init; }
+}
+
+public record ClearQueueRequest
+{
+    public bool KeepCurrentTrack { get; init; } = false;
+}
+
+public record ReplaceQueueRequest
+{
+    [Required]
+    [MinLength(1, ErrorMessage = "At least one track must be provided")]
+    [MaxLength(1000, ErrorMessage = "Queue cannot exceed 1000 tracks")]
+    public required List<string> TrackIds { get; init; }
+    
+    [Range(0, int.MaxValue, ErrorMessage = "Start index must be non-negative")]
+    public int StartIndex { get; init; } = 0;
+    
+    [StringLength(100)]
+    public string? Source { get; init; }
+}

--- a/tests/Audiarr.Tests/DTOs/QueueDtoTests.cs
+++ b/tests/Audiarr.Tests/DTOs/QueueDtoTests.cs
@@ -1,0 +1,392 @@
+using System.Text.Json;
+using Audiarr.Core.DTOs;
+using Audiarr.Core.Entities;
+using Xunit;
+
+namespace Audiarr.Tests.DTOs;
+
+public class QueueDtoTests
+{
+    #region QueueStateDto Tests
+
+    [Fact]
+    public void QueueStateDto_DefaultValues_AreCorrect()
+    {
+        // Arrange & Act
+        var dto = new QueueStateDto();
+
+        // Assert
+        Assert.Equal(string.Empty, dto.QueueId);
+        Assert.Equal(string.Empty, dto.UserId);
+        Assert.NotNull(dto.TrackIds);
+        Assert.Empty(dto.TrackIds);
+        Assert.Null(dto.CurrentTrackId);
+        Assert.Equal(0, dto.CurrentIndex);
+        Assert.Equal(RepeatMode.None, dto.RepeatMode);
+        Assert.False(dto.IsShuffled);
+        Assert.Equal(0, dto.TotalTracks);
+        Assert.Null(dto.QueueSource);
+        Assert.Equal(0, dto.Version);
+    }
+
+    [Fact]
+    public void QueueStateDto_CanSetAllProperties()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var trackIds = new List<string> { "track1", "track2", "track3" };
+
+        // Act
+        var dto = new QueueStateDto
+        {
+            QueueId = "queue123",
+            UserId = "user456",
+            TrackIds = trackIds,
+            CurrentTrackId = "track2",
+            CurrentIndex = 1,
+            RepeatMode = RepeatMode.All,
+            IsShuffled = true,
+            TotalTracks = 3,
+            QueueSource = "playlist",
+            LastActivity = now,
+            Version = 2
+        };
+
+        // Assert
+        Assert.Equal("queue123", dto.QueueId);
+        Assert.Equal("user456", dto.UserId);
+        Assert.Equal(3, dto.TrackIds.Count);
+        Assert.Equal("track2", dto.CurrentTrackId);
+        Assert.Equal(1, dto.CurrentIndex);
+        Assert.Equal(RepeatMode.All, dto.RepeatMode);
+        Assert.True(dto.IsShuffled);
+        Assert.Equal(3, dto.TotalTracks);
+        Assert.Equal("playlist", dto.QueueSource);
+        Assert.Equal(now, dto.LastActivity);
+        Assert.Equal(2, dto.Version);
+    }
+
+    [Fact]
+    public void QueueStateDto_SerializesCorrectly()
+    {
+        // Arrange
+        var dto = new QueueStateDto
+        {
+            QueueId = "queue123",
+            UserId = "user456",
+            TrackIds = new List<string> { "track1", "track2" },
+            CurrentTrackId = "track1",
+            CurrentIndex = 0,
+            RepeatMode = RepeatMode.One,
+            IsShuffled = false,
+            TotalTracks = 2,
+            QueueSource = "album",
+            LastActivity = new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+            Version = 1
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(dto);
+        var deserialized = JsonSerializer.Deserialize<QueueStateDto>(json);
+
+        // Assert
+        Assert.NotNull(deserialized);
+        Assert.Equal(dto.QueueId, deserialized.QueueId);
+        Assert.Equal(dto.UserId, deserialized.UserId);
+        Assert.Equal(dto.TrackIds.Count, deserialized.TrackIds.Count);
+        Assert.Equal(dto.CurrentTrackId, deserialized.CurrentTrackId);
+        Assert.Equal(dto.CurrentIndex, deserialized.CurrentIndex);
+        Assert.Equal(dto.RepeatMode, deserialized.RepeatMode);
+        Assert.Equal(dto.IsShuffled, deserialized.IsShuffled);
+        Assert.Equal(dto.TotalTracks, deserialized.TotalTracks);
+        Assert.Equal(dto.QueueSource, deserialized.QueueSource);
+        Assert.Equal(dto.LastActivity, deserialized.LastActivity);
+        Assert.Equal(dto.Version, deserialized.Version);
+    }
+
+    [Theory]
+    [InlineData(RepeatMode.None)]
+    [InlineData(RepeatMode.One)]
+    [InlineData(RepeatMode.All)]
+    public void QueueStateDto_RepeatModeEnum_SerializesCorrectly(RepeatMode mode)
+    {
+        // Arrange
+        var dto = new QueueStateDto { RepeatMode = mode };
+
+        // Act
+        var json = JsonSerializer.Serialize(dto);
+        var deserialized = JsonSerializer.Deserialize<QueueStateDto>(json);
+
+        // Assert
+        Assert.NotNull(deserialized);
+        Assert.Equal(mode, deserialized.RepeatMode);
+    }
+
+    [Fact]
+    public void QueueStateDto_EmptyTrackIds_SerializesAsEmptyArray()
+    {
+        // Arrange
+        var dto = new QueueStateDto
+        {
+            TrackIds = new List<string>()
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(dto);
+
+        // Assert
+        Assert.Contains("\"TrackIds\":[]", json.Replace(" ", ""));
+    }
+
+    [Fact]
+    public void QueueStateDto_NullCurrentTrackId_SerializesAsNull()
+    {
+        // Arrange
+        var dto = new QueueStateDto
+        {
+            CurrentTrackId = null
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(dto);
+        var deserialized = JsonSerializer.Deserialize<QueueStateDto>(json);
+
+        // Assert
+        Assert.NotNull(deserialized);
+        Assert.Null(deserialized.CurrentTrackId);
+    }
+
+    #endregion
+
+    #region QueueItemDto Tests
+
+    [Fact]
+    public void QueueItemDto_DefaultValues_AreCorrect()
+    {
+        // Arrange & Act
+        var dto = new QueueItemDto();
+
+        // Assert
+        Assert.Equal(0, dto.Index);
+        Assert.Equal(string.Empty, dto.TrackId);
+        Assert.Null(dto.Track);
+        Assert.Equal(default(DateTime), dto.AddedAt);
+        Assert.Null(dto.Source);
+    }
+
+    [Fact]
+    public void QueueItemDto_CanSetAllProperties()
+    {
+        // Arrange
+        var track = new TrackDto
+        {
+            Id = "track123",
+            Title = "Test Song",
+            ArtistName = "Test Artist",
+            AlbumTitle = "Test Album",
+            DurationMs = 180000
+        };
+        var addedAt = DateTime.UtcNow;
+
+        // Act
+        var dto = new QueueItemDto
+        {
+            Index = 5,
+            TrackId = "track123",
+            Track = track,
+            AddedAt = addedAt,
+            Source = "search"
+        };
+
+        // Assert
+        Assert.Equal(5, dto.Index);
+        Assert.Equal("track123", dto.TrackId);
+        Assert.NotNull(dto.Track);
+        Assert.Equal("Test Song", dto.Track.Title);
+        Assert.Equal(addedAt, dto.AddedAt);
+        Assert.Equal("search", dto.Source);
+    }
+
+    [Fact]
+    public void QueueItemDto_SerializesCorrectly()
+    {
+        // Arrange
+        var dto = new QueueItemDto
+        {
+            Index = 10,
+            TrackId = "track456",
+            Track = new TrackDto
+            {
+                Id = "track456",
+                Title = "Another Song",
+                ArtistName = "Another Artist",
+                AlbumTitle = "Another Album",
+                DurationMs = 240000
+            },
+            AddedAt = new DateTime(2025, 1, 1, 15, 30, 0, DateTimeKind.Utc),
+            Source = "playlist"
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(dto);
+        var deserialized = JsonSerializer.Deserialize<QueueItemDto>(json);
+
+        // Assert
+        Assert.NotNull(deserialized);
+        Assert.Equal(dto.Index, deserialized.Index);
+        Assert.Equal(dto.TrackId, deserialized.TrackId);
+        Assert.NotNull(deserialized.Track);
+        Assert.Equal(dto.Track.Id, deserialized.Track.Id);
+        Assert.Equal(dto.Track.Title, deserialized.Track.Title);
+        Assert.Equal(dto.AddedAt, deserialized.AddedAt);
+        Assert.Equal(dto.Source, deserialized.Source);
+    }
+
+    [Fact]
+    public void QueueItemDto_WithNullSource_SerializesCorrectly()
+    {
+        // Arrange
+        var dto = new QueueItemDto
+        {
+            Index = 0,
+            TrackId = "track789",
+            Track = new TrackDto { Id = "track789", Title = "Song" },
+            AddedAt = DateTime.UtcNow,
+            Source = null
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(dto);
+        var deserialized = JsonSerializer.Deserialize<QueueItemDto>(json);
+
+        // Assert
+        Assert.NotNull(deserialized);
+        Assert.Null(deserialized.Source);
+    }
+
+    [Fact]
+    public void QueueItemDto_ListSerialization_WorksCorrectly()
+    {
+        // Arrange
+        var items = new List<QueueItemDto>
+        {
+            new QueueItemDto
+            {
+                Index = 0,
+                TrackId = "track1",
+                Track = new TrackDto { Id = "track1", Title = "Song 1" },
+                AddedAt = DateTime.UtcNow,
+                Source = "album"
+            },
+            new QueueItemDto
+            {
+                Index = 1,
+                TrackId = "track2",
+                Track = new TrackDto { Id = "track2", Title = "Song 2" },
+                AddedAt = DateTime.UtcNow,
+                Source = "album"
+            }
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(items);
+        var deserialized = JsonSerializer.Deserialize<List<QueueItemDto>>(json);
+
+        // Assert
+        Assert.NotNull(deserialized);
+        Assert.Equal(2, deserialized.Count);
+        Assert.Equal("track1", deserialized[0].TrackId);
+        Assert.Equal("track2", deserialized[1].TrackId);
+    }
+
+    #endregion
+
+    #region Integration Tests
+
+    [Fact]
+    public void QueueStateDto_CanRepresentEmptyQueue()
+    {
+        // Arrange & Act
+        var emptyQueue = new QueueStateDto
+        {
+            QueueId = "empty-queue",
+            UserId = "user123",
+            TrackIds = new List<string>(),
+            CurrentTrackId = null,
+            CurrentIndex = 0,
+            TotalTracks = 0,
+            RepeatMode = RepeatMode.None,
+            IsShuffled = false
+        };
+
+        // Assert
+        Assert.Empty(emptyQueue.TrackIds);
+        Assert.Null(emptyQueue.CurrentTrackId);
+        Assert.Equal(0, emptyQueue.TotalTracks);
+    }
+
+    [Fact]
+    public void QueueStateDto_CanRepresentShuffledQueue()
+    {
+        // Arrange & Act
+        var shuffledQueue = new QueueStateDto
+        {
+            QueueId = "shuffled-queue",
+            UserId = "user123",
+            TrackIds = new List<string> { "track3", "track1", "track5", "track2", "track4" },
+            CurrentTrackId = "track3",
+            CurrentIndex = 0,
+            TotalTracks = 5,
+            RepeatMode = RepeatMode.All,
+            IsShuffled = true,
+            QueueSource = "library"
+        };
+
+        // Assert
+        Assert.True(shuffledQueue.IsShuffled);
+        Assert.Equal(5, shuffledQueue.TotalTracks);
+        Assert.Equal(RepeatMode.All, shuffledQueue.RepeatMode);
+    }
+
+    [Fact]
+    public void QueueItemDto_CanRepresentQueueWithFullTrackInfo()
+    {
+        // Arrange
+        var fullTrack = new TrackDto
+        {
+            Id = "track-full",
+            Title = "Complete Track",
+            ArtistId = "artist123",
+            ArtistName = "Full Artist",
+            AlbumId = "album456",
+            AlbumTitle = "Full Album",
+            TrackNumber = 5,
+            DiscNumber = 1,
+            DurationMs = 210000,
+            Genre = "Rock",
+            Year = 2024,
+            FileSize = 8500000,
+            Bitrate = 320,
+            Codec = "MP3",
+            FilePath = "/music/track.mp3"
+        };
+
+        // Act
+        var queueItem = new QueueItemDto
+        {
+            Index = 0,
+            TrackId = fullTrack.Id,
+            Track = fullTrack,
+            AddedAt = DateTime.UtcNow,
+            Source = "album"
+        };
+
+        // Assert
+        Assert.NotNull(queueItem.Track);
+        Assert.Equal("Complete Track", queueItem.Track.Title);
+        Assert.Equal(210000, queueItem.Track.DurationMs);
+        Assert.Equal("Rock", queueItem.Track.Genre);
+    }
+
+    #endregion
+}

--- a/tests/Audiarr.Tests/DTOs/Requests/QueueRequestsTests.cs
+++ b/tests/Audiarr.Tests/DTOs/Requests/QueueRequestsTests.cs
@@ -1,0 +1,507 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+using Audiarr.Core.DTOs.Requests;
+using Audiarr.Core.Entities;
+using Xunit;
+
+namespace Audiarr.Tests.DTOs.Requests;
+
+public class QueueRequestsTests
+{
+    #region AddToQueueRequest Tests
+    
+    [Fact]
+    public void AddToQueueRequest_ValidRequest_PassesValidation()
+    {
+        // Arrange
+        var request = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track1", "track2", "track3" },
+            Source = "album",
+            PlayNext = true
+        };
+
+        // Act
+        var validationContext = new ValidationContext(request);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, true);
+
+        // Assert
+        Assert.True(isValid);
+        Assert.Empty(validationResults);
+    }
+
+    [Fact]
+    public void AddToQueueRequest_EmptyTrackIds_FailsValidation()
+    {
+        // Arrange
+        var request = new AddToQueueRequest
+        {
+            TrackIds = new List<string>()
+        };
+
+        // Act
+        var validationContext = new ValidationContext(request);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, true);
+
+        // Assert
+        Assert.False(isValid);
+        Assert.NotEmpty(validationResults);
+        Assert.Contains(validationResults, r => r.ErrorMessage!.Contains("At least one track must be provided"));
+    }
+
+    [Fact]
+    public void AddToQueueRequest_TooManyTracks_FailsValidation()
+    {
+        // Arrange
+        var trackIds = Enumerable.Range(1, 101).Select(i => $"track{i}").ToList();
+        var request = new AddToQueueRequest
+        {
+            TrackIds = trackIds
+        };
+
+        // Act
+        var validationContext = new ValidationContext(request);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, true);
+
+        // Assert
+        Assert.False(isValid);
+        Assert.NotEmpty(validationResults);
+        Assert.Contains(validationResults, r => r.ErrorMessage!.Contains("Cannot add more than 100 tracks"));
+    }
+
+    [Fact]
+    public void AddToQueueRequest_ExactlyHundredTracks_PassesValidation()
+    {
+        // Arrange
+        var trackIds = Enumerable.Range(1, 100).Select(i => $"track{i}").ToList();
+        var request = new AddToQueueRequest
+        {
+            TrackIds = trackIds
+        };
+
+        // Act
+        var validationContext = new ValidationContext(request);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, true);
+
+        // Assert
+        Assert.True(isValid);
+        Assert.Empty(validationResults);
+    }
+
+    [Fact]
+    public void AddToQueueRequest_DefaultPlayNext_IsFalse()
+    {
+        // Arrange & Act
+        var request = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track1" }
+        };
+
+        // Assert
+        Assert.False(request.PlayNext);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("album")]
+    [InlineData("playlist")]
+    [InlineData("This is a valid source string that is exactly 100 characters long to test the maximum limit!!!")]
+    public void AddToQueueRequest_ValidSource_PassesValidation(string? source)
+    {
+        // Arrange
+        var request = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track1" },
+            Source = source
+        };
+
+        // Act
+        var validationContext = new ValidationContext(request);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, true);
+
+        // Assert
+        Assert.True(isValid);
+        Assert.Empty(validationResults);
+    }
+
+    [Fact]
+    public void AddToQueueRequest_SourceTooLong_FailsValidation()
+    {
+        // Arrange
+        var request = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track1" },
+            Source = new string('x', 101)
+        };
+
+        // Act
+        var validationContext = new ValidationContext(request);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, true);
+
+        // Assert
+        Assert.False(isValid);
+        Assert.NotEmpty(validationResults);
+    }
+
+    #endregion
+
+    #region UpdateQueueRequest Tests
+
+    [Fact]
+    public void UpdateQueueRequest_AllFieldsOptional_PassesValidation()
+    {
+        // Arrange
+        var request = new UpdateQueueRequest();
+
+        // Act
+        var validationContext = new ValidationContext(request);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, true);
+
+        // Assert
+        Assert.True(isValid);
+        Assert.Empty(validationResults);
+        Assert.Null(request.RepeatMode);
+        Assert.Null(request.IsShuffled);
+        Assert.Null(request.CurrentIndex);
+    }
+
+    [Fact]
+    public void UpdateQueueRequest_ValidValues_PassesValidation()
+    {
+        // Arrange
+        var request = new UpdateQueueRequest
+        {
+            RepeatMode = RepeatMode.All,
+            IsShuffled = true,
+            CurrentIndex = 5
+        };
+
+        // Act
+        var validationContext = new ValidationContext(request);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, true);
+
+        // Assert
+        Assert.True(isValid);
+        Assert.Empty(validationResults);
+    }
+
+    [Fact]
+    public void UpdateQueueRequest_NegativeIndex_FailsValidation()
+    {
+        // Arrange
+        var request = new UpdateQueueRequest
+        {
+            CurrentIndex = -1
+        };
+
+        // Act
+        var validationContext = new ValidationContext(request);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, true);
+
+        // Assert
+        Assert.False(isValid);
+        Assert.NotEmpty(validationResults);
+        Assert.Contains(validationResults, r => r.ErrorMessage!.Contains("Current index must be non-negative"));
+    }
+
+    [Theory]
+    [InlineData(RepeatMode.None)]
+    [InlineData(RepeatMode.One)]
+    [InlineData(RepeatMode.All)]
+    public void UpdateQueueRequest_AllRepeatModes_AreValid(RepeatMode mode)
+    {
+        // Arrange
+        var request = new UpdateQueueRequest
+        {
+            RepeatMode = mode
+        };
+
+        // Act
+        var validationContext = new ValidationContext(request);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, true);
+
+        // Assert
+        Assert.True(isValid);
+        Assert.Empty(validationResults);
+    }
+
+    #endregion
+
+    #region ReorderQueueRequest Tests
+
+    [Fact]
+    public void ReorderQueueRequest_ValidRequest_PassesValidation()
+    {
+        // Arrange
+        var request = new ReorderQueueRequest
+        {
+            TrackId = "track123",
+            NewIndex = 5
+        };
+
+        // Act
+        var validationContext = new ValidationContext(request);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, true);
+
+        // Assert
+        Assert.True(isValid);
+        Assert.Empty(validationResults);
+    }
+
+    [Fact]
+    public void ReorderQueueRequest_NegativeIndex_FailsValidation()
+    {
+        // Arrange
+        var request = new ReorderQueueRequest
+        {
+            TrackId = "track123",
+            NewIndex = -1
+        };
+
+        // Act
+        var validationContext = new ValidationContext(request);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, true);
+
+        // Assert
+        Assert.False(isValid);
+        Assert.NotEmpty(validationResults);
+        Assert.Contains(validationResults, r => r.ErrorMessage!.Contains("New index must be non-negative"));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(100)]
+    [InlineData(999)]
+    [InlineData(int.MaxValue)]
+    public void ReorderQueueRequest_ValidIndices_PassValidation(int index)
+    {
+        // Arrange
+        var request = new ReorderQueueRequest
+        {
+            TrackId = "track123",
+            NewIndex = index
+        };
+
+        // Act
+        var validationContext = new ValidationContext(request);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, true);
+
+        // Assert
+        Assert.True(isValid);
+        Assert.Empty(validationResults);
+    }
+
+    #endregion
+
+    #region ClearQueueRequest Tests
+
+    [Fact]
+    public void ClearQueueRequest_DefaultKeepCurrentTrack_IsFalse()
+    {
+        // Arrange & Act
+        var request = new ClearQueueRequest();
+
+        // Assert
+        Assert.False(request.KeepCurrentTrack);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ClearQueueRequest_CanSetKeepCurrentTrack(bool keepCurrent)
+    {
+        // Arrange & Act
+        var request = new ClearQueueRequest
+        {
+            KeepCurrentTrack = keepCurrent
+        };
+
+        // Assert
+        Assert.Equal(keepCurrent, request.KeepCurrentTrack);
+    }
+
+    #endregion
+
+    #region ReplaceQueueRequest Tests
+
+    [Fact]
+    public void ReplaceQueueRequest_ValidRequest_PassesValidation()
+    {
+        // Arrange
+        var request = new ReplaceQueueRequest
+        {
+            TrackIds = new List<string> { "track1", "track2", "track3" },
+            StartIndex = 0,
+            Source = "playlist"
+        };
+
+        // Act
+        var validationContext = new ValidationContext(request);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, true);
+
+        // Assert
+        Assert.True(isValid);
+        Assert.Empty(validationResults);
+    }
+
+    [Fact]
+    public void ReplaceQueueRequest_EmptyTrackIds_FailsValidation()
+    {
+        // Arrange
+        var request = new ReplaceQueueRequest
+        {
+            TrackIds = new List<string>()
+        };
+
+        // Act
+        var validationContext = new ValidationContext(request);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, true);
+
+        // Assert
+        Assert.False(isValid);
+        Assert.NotEmpty(validationResults);
+        Assert.Contains(validationResults, r => r.ErrorMessage!.Contains("At least one track must be provided"));
+    }
+
+    [Fact]
+    public void ReplaceQueueRequest_TooManyTracks_FailsValidation()
+    {
+        // Arrange
+        var trackIds = Enumerable.Range(1, 1001).Select(i => $"track{i}").ToList();
+        var request = new ReplaceQueueRequest
+        {
+            TrackIds = trackIds
+        };
+
+        // Act
+        var validationContext = new ValidationContext(request);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, true);
+
+        // Assert
+        Assert.False(isValid);
+        Assert.NotEmpty(validationResults);
+        Assert.Contains(validationResults, r => r.ErrorMessage!.Contains("Queue cannot exceed 1000 tracks"));
+    }
+
+    [Fact]
+    public void ReplaceQueueRequest_ExactlyThousandTracks_PassesValidation()
+    {
+        // Arrange
+        var trackIds = Enumerable.Range(1, 1000).Select(i => $"track{i}").ToList();
+        var request = new ReplaceQueueRequest
+        {
+            TrackIds = trackIds
+        };
+
+        // Act
+        var validationContext = new ValidationContext(request);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, true);
+
+        // Assert
+        Assert.True(isValid);
+        Assert.Empty(validationResults);
+    }
+
+    [Fact]
+    public void ReplaceQueueRequest_DefaultStartIndex_IsZero()
+    {
+        // Arrange & Act
+        var request = new ReplaceQueueRequest
+        {
+            TrackIds = new List<string> { "track1" }
+        };
+
+        // Assert
+        Assert.Equal(0, request.StartIndex);
+    }
+
+    [Fact]
+    public void ReplaceQueueRequest_NegativeStartIndex_FailsValidation()
+    {
+        // Arrange
+        var request = new ReplaceQueueRequest
+        {
+            TrackIds = new List<string> { "track1" },
+            StartIndex = -1
+        };
+
+        // Act
+        var validationContext = new ValidationContext(request);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, true);
+
+        // Assert
+        Assert.False(isValid);
+        Assert.NotEmpty(validationResults);
+        Assert.Contains(validationResults, r => r.ErrorMessage!.Contains("Start index must be non-negative"));
+    }
+
+    #endregion
+
+    #region Serialization Tests
+
+    [Fact]
+    public void QueueRequests_SerializeAndDeserialize_Correctly()
+    {
+        // Arrange
+        var addRequest = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track1", "track2" },
+            Source = "album",
+            PlayNext = true
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(addRequest);
+        var deserialized = JsonSerializer.Deserialize<AddToQueueRequest>(json);
+
+        // Assert
+        Assert.NotNull(deserialized);
+        Assert.Equal(addRequest.TrackIds.Count, deserialized.TrackIds.Count);
+        Assert.Equal(addRequest.Source, deserialized.Source);
+        Assert.Equal(addRequest.PlayNext, deserialized.PlayNext);
+    }
+
+    [Fact]
+    public void UpdateQueueRequest_EnumSerialization_WorksCorrectly()
+    {
+        // Arrange
+        var request = new UpdateQueueRequest
+        {
+            RepeatMode = RepeatMode.All,
+            IsShuffled = true,
+            CurrentIndex = 10
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(request);
+        var deserialized = JsonSerializer.Deserialize<UpdateQueueRequest>(json);
+
+        // Assert
+        Assert.NotNull(deserialized);
+        Assert.Equal(RepeatMode.All, deserialized.RepeatMode);
+        Assert.True(deserialized.IsShuffled);
+        Assert.Equal(10, deserialized.CurrentIndex);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
- Add QueueStateDto for queue state representation
- Add QueueItemDto for individual queue items
- Create request models: AddToQueue, UpdateQueue, ReorderQueue, ClearQueue, ReplaceQueue
- Include proper validation attributes with constraints
- Add comprehensive test coverage (51 tests)
- Test DTO serialization/deserialization
- Validate request model constraints and edge cases
- All tests passing successfully