### PR TITLE
feat: Implement Queue Playback Control Endpoints (#59)

### DIFF
--- a/src/Audiarr.Api/Endpoints/QueueEndpoints.cs
+++ b/src/Audiarr.Api/Endpoints/QueueEndpoints.cs
@@ -236,6 +236,152 @@ public static class QueueEndpoints
         .Produces<QueueStateDto>()
         .Produces<ProblemDetails>(400)
         .Produces(401);
+
+        // Playback Control Endpoints
+
+        // PUT /api/v2/queue/settings - Update queue settings (repeat/shuffle)
+        group.MapPut("/settings", async (
+            [FromBody] UpdateQueueRequest request,
+            ClaimsPrincipal user,
+            IQueueService queueService) =>
+        {
+            var userId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Results.Unauthorized();
+            }
+
+            try
+            {
+                var queue = await queueService.UpdateQueueSettingsAsync(userId, request);
+                return Results.Ok(queue);
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                return Results.BadRequest(new ProblemDetails
+                {
+                    Title = "Invalid request",
+                    Detail = ex.Message,
+                    Status = 400
+                });
+            }
+        })
+        .WithName("UpdatePlaybackSettings")
+        .WithSummary("Update queue settings")
+        .WithDescription("Updates repeat mode and shuffle settings for the playback queue")
+        .Produces<QueueStateDto>()
+        .Produces<ProblemDetails>(400)
+        .Produces(401);
+
+        // POST /api/v2/queue/next - Skip to next track
+        group.MapPost("/next", async (
+            ClaimsPrincipal user,
+            IQueueService queueService) =>
+        {
+            var userId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Results.Unauthorized();
+            }
+
+            try
+            {
+                var queue = await queueService.NextTrackAsync(userId);
+                return Results.Ok(queue);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.NotFound(new ProblemDetails
+                {
+                    Title = "Queue empty",
+                    Detail = ex.Message,
+                    Status = 404
+                });
+            }
+        })
+        .WithName("NextTrack")
+        .WithSummary("Skip to next track")
+        .WithDescription("Moves to the next track in the queue, respecting repeat mode settings")
+        .Produces<QueueStateDto>()
+        .Produces<ProblemDetails>(404)
+        .Produces(401);
+
+        // POST /api/v2/queue/previous - Go to previous track
+        group.MapPost("/previous", async (
+            ClaimsPrincipal user,
+            IQueueService queueService) =>
+        {
+            var userId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Results.Unauthorized();
+            }
+
+            try
+            {
+                var queue = await queueService.PreviousTrackAsync(userId);
+                return Results.Ok(queue);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.NotFound(new ProblemDetails
+                {
+                    Title = "Queue empty",
+                    Detail = ex.Message,
+                    Status = 404
+                });
+            }
+        })
+        .WithName("PreviousTrack")
+        .WithSummary("Go to previous track")
+        .WithDescription("Moves to the previous track in the queue, respecting repeat mode settings")
+        .Produces<QueueStateDto>()
+        .Produces<ProblemDetails>(404)
+        .Produces(401);
+
+        // PUT /api/v2/queue/position/{index} - Jump to specific track
+        group.MapPut("/position/{index:int}", async (
+            int index,
+            ClaimsPrincipal user,
+            IQueueService queueService) =>
+        {
+            var userId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Results.Unauthorized();
+            }
+
+            try
+            {
+                var queue = await queueService.JumpToPositionAsync(userId, index);
+                return Results.Ok(queue);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.NotFound(new ProblemDetails
+                {
+                    Title = "Queue empty",
+                    Detail = ex.Message,
+                    Status = 404
+                });
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                return Results.BadRequest(new ProblemDetails
+                {
+                    Title = "Invalid index",
+                    Detail = ex.Message,
+                    Status = 400
+                });
+            }
+        })
+        .WithName("JumpToPosition")
+        .WithSummary("Jump to specific track")
+        .WithDescription("Jumps to a specific track position in the queue")
+        .Produces<QueueStateDto>()
+        .Produces<ProblemDetails>(400)
+        .Produces<ProblemDetails>(404)
+        .Produces(401);
     }
 }
 

--- a/src/Audiarr.Core/Services/IQueueService.cs
+++ b/src/Audiarr.Core/Services/IQueueService.cs
@@ -12,4 +12,9 @@ public interface IQueueService
     Task<QueueStateDto> ReorderQueueAsync(string userId, ReorderQueueRequest request);
     Task<QueueStateDto> ReplaceQueueAsync(string userId, ReplaceQueueRequest request);
     Task<QueueStateDto> UpdateQueueSettingsAsync(string userId, UpdateQueueRequest request);
+    
+    // Playback control methods
+    Task<QueueStateDto> NextTrackAsync(string userId);
+    Task<QueueStateDto> PreviousTrackAsync(string userId);
+    Task<QueueStateDto> JumpToPositionAsync(string userId, int index);
 }

--- a/src/Audiarr.Services/QueueService.cs
+++ b/src/Audiarr.Services/QueueService.cs
@@ -380,6 +380,147 @@ public class QueueService : IQueueService
         return queue;
     }
 
+    public async Task<QueueStateDto> NextTrackAsync(string userId)
+    {
+        var queue = await GetOrCreateQueueAsync(userId);
+        var queueState = queue.QueueState;
+
+        // Ensure TrackIds is initialized
+        queueState.TrackIds ??= new List<string>();
+
+        if (!queueState.TrackIds.Any())
+        {
+            throw new InvalidOperationException("Queue is empty");
+        }
+
+        var trackCount = queueState.TrackIds.Count;
+        var currentIndex = queue.CurrentIndex;
+        int nextIndex;
+
+        // Handle based on repeat mode
+        if (queue.RepeatMode == RepeatMode.One)
+        {
+            // Always stay on current track when repeat one is enabled
+            nextIndex = currentIndex;
+        }
+        else
+        {
+            nextIndex = currentIndex + 1;
+            
+            // Handle edge cases at end of queue
+            if (nextIndex >= trackCount)
+            {
+                switch (queue.RepeatMode)
+                {
+                    case RepeatMode.All:
+                        // Loop back to first track
+                        nextIndex = 0;
+                        break;
+                    case RepeatMode.None:
+                    default:
+                        // Stay on last track
+                        nextIndex = trackCount - 1;
+                        break;
+                }
+            }
+        }
+
+        queue.CurrentIndex = nextIndex;
+        queue.CurrentTrackId = queueState.TrackIds[nextIndex];
+        queue.UpdateActivity();
+        queue.Version++;
+
+        await _context.SaveChangesAsync();
+        _logger.LogInformation("Moved to next track (index {Index}) in queue for user {UserId}", nextIndex, userId);
+
+        return MapToDto(queue);
+    }
+
+    public async Task<QueueStateDto> PreviousTrackAsync(string userId)
+    {
+        var queue = await GetOrCreateQueueAsync(userId);
+        var queueState = queue.QueueState;
+
+        // Ensure TrackIds is initialized
+        queueState.TrackIds ??= new List<string>();
+
+        if (!queueState.TrackIds.Any())
+        {
+            throw new InvalidOperationException("Queue is empty");
+        }
+
+        var trackCount = queueState.TrackIds.Count;
+        var currentIndex = queue.CurrentIndex;
+        int previousIndex;
+
+        // Handle based on repeat mode
+        if (queue.RepeatMode == RepeatMode.One)
+        {
+            // Always stay on current track when repeat one is enabled
+            previousIndex = currentIndex;
+        }
+        else
+        {
+            previousIndex = currentIndex - 1;
+            
+            // Handle edge cases at start of queue
+            if (previousIndex < 0)
+            {
+                switch (queue.RepeatMode)
+                {
+                    case RepeatMode.All:
+                        // Loop to last track
+                        previousIndex = trackCount - 1;
+                        break;
+                    case RepeatMode.None:
+                    default:
+                        // Stay on first track
+                        previousIndex = 0;
+                        break;
+                }
+            }
+        }
+
+        queue.CurrentIndex = previousIndex;
+        queue.CurrentTrackId = queueState.TrackIds[previousIndex];
+        queue.UpdateActivity();
+        queue.Version++;
+
+        await _context.SaveChangesAsync();
+        _logger.LogInformation("Moved to previous track (index {Index}) in queue for user {UserId}", previousIndex, userId);
+
+        return MapToDto(queue);
+    }
+
+    public async Task<QueueStateDto> JumpToPositionAsync(string userId, int index)
+    {
+        var queue = await GetOrCreateQueueAsync(userId);
+        var queueState = queue.QueueState;
+
+        // Ensure TrackIds is initialized
+        queueState.TrackIds ??= new List<string>();
+
+        if (!queueState.TrackIds.Any())
+        {
+            throw new InvalidOperationException("Queue is empty");
+        }
+
+        if (index < 0 || index >= queueState.TrackIds.Count)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index), $"Index {index} is out of range. Queue has {queueState.TrackIds.Count} tracks.");
+        }
+
+        queue.CurrentIndex = index;
+        queue.CurrentTrackId = queueState.TrackIds[index];
+        queue.UpdateActivity();
+        queue.Version++;
+
+        await _context.SaveChangesAsync();
+        _logger.LogInformation("Jumped to position {Index} in queue for user {UserId}", index, userId);
+
+        return MapToDto(queue);
+    }
+
     private QueueStateDto MapToDto(PlaybackQueue queue)
     {
         var queueState = queue.QueueState;

--- a/tests/Audiarr.Tests/Endpoints/QueuePlaybackEndpointsTests.cs
+++ b/tests/Audiarr.Tests/Endpoints/QueuePlaybackEndpointsTests.cs
@@ -1,0 +1,423 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Audiarr.Core.DTOs;
+using Audiarr.Core.DTOs.Requests;
+using Audiarr.Core.Entities;
+using Audiarr.Data.Context;
+using Xunit;
+
+namespace Audiarr.Tests.Endpoints;
+
+public class QueuePlaybackEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+
+    public QueuePlaybackEndpointsTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                // Remove the existing DbContext registration
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<AudiarrContext>));
+                if (descriptor != null)
+                {
+                    services.Remove(descriptor);
+                }
+
+                // Add in-memory database for testing
+                services.AddDbContext<AudiarrContext>(options =>
+                {
+                    options.UseInMemoryDatabase("TestDb_" + Guid.NewGuid());
+                });
+
+                // Ensure the database is created and seeded
+                var sp = services.BuildServiceProvider();
+                using var scope = sp.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<AudiarrContext>();
+                db.Database.EnsureCreated();
+                SeedTestData(db);
+            });
+        });
+
+        _client = _factory.CreateClient();
+    }
+
+    private void SeedTestData(AudiarrContext context)
+    {
+        // Add test user
+        var user = new User
+        {
+            Id = "test-user",
+            Username = "testuser",
+            Email = "test@example.com",
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("testpass"),
+            Role = "user"
+        };
+        context.Users.Add(user);
+
+        // Add test tracks
+        var artist = new Artist
+        {
+            Id = "artist-1",
+            Name = "Test Artist"
+        };
+        context.Artists.Add(artist);
+
+        var album = new Album
+        {
+            Id = "album-1",
+            Title = "Test Album",
+            ArtistId = artist.Id
+        };
+        context.Albums.Add(album);
+
+        for (int i = 1; i <= 5; i++)
+        {
+            var track = new Track
+            {
+                Id = $"track-{i}",
+                Title = $"Test Track {i}",
+                FilePath = $"/music/track{i}.mp3",
+                DurationMs = 180000,
+                ArtistId = artist.Id,
+                AlbumId = album.Id,
+                TrackNumber = i
+            };
+            context.Tracks.Add(track);
+        }
+
+        context.SaveChanges();
+    }
+
+    private async Task<string> GetAuthTokenAsync()
+    {
+        var loginRequest = new { username = "testuser", password = "testpass" };
+        var response = await _client.PostAsJsonAsync("/api/v2/auth/login", loginRequest);
+        response.EnsureSuccessStatusCode();
+        
+        var content = await response.Content.ReadAsStringAsync();
+        var authResponse = JsonSerializer.Deserialize<JsonElement>(content);
+        return authResponse.GetProperty("accessToken").GetString()!;
+    }
+
+    private async Task<QueueStateDto> SetupQueueWithTracksAsync(string token)
+    {
+        _client.DefaultRequestHeaders.Authorization = 
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+
+        var replaceRequest = new ReplaceQueueRequest
+        {
+            TrackIds = new List<string> { "track-1", "track-2", "track-3", "track-4", "track-5" },
+            StartIndex = 0
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/v2/queue/replace", replaceRequest);
+        response.EnsureSuccessStatusCode();
+        
+        return await response.Content.ReadFromJsonAsync<QueueStateDto>() 
+            ?? throw new InvalidOperationException("Failed to setup queue");
+    }
+
+    #region PUT /api/v2/queue/settings Tests
+
+    [Fact]
+    public async Task UpdateSettings_Should_Update_RepeatMode_And_Shuffle()
+    {
+        // Arrange
+        var token = await GetAuthTokenAsync();
+        await SetupQueueWithTracksAsync(token);
+
+        var updateRequest = new UpdateQueueRequest
+        {
+            RepeatMode = RepeatMode.All,
+            IsShuffled = true
+        };
+
+        // Act
+        var response = await _client.PutAsJsonAsync("/api/v2/queue/settings", updateRequest);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        
+        var result = await response.Content.ReadFromJsonAsync<QueueStateDto>();
+        Assert.NotNull(result);
+        Assert.Equal(RepeatMode.All, result.RepeatMode);
+        Assert.True(result.IsShuffled);
+    }
+
+    [Fact]
+    public async Task UpdateSettings_Should_Return_401_When_Not_Authenticated()
+    {
+        // Arrange
+        var updateRequest = new UpdateQueueRequest
+        {
+            RepeatMode = RepeatMode.One
+        };
+
+        // Act
+        var response = await _client.PutAsJsonAsync("/api/v2/queue/settings", updateRequest);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    #endregion
+
+    #region POST /api/v2/queue/next Tests
+
+    [Fact]
+    public async Task NextTrack_Should_Move_To_Next_Track()
+    {
+        // Arrange
+        var token = await GetAuthTokenAsync();
+        var initialQueue = await SetupQueueWithTracksAsync(token);
+        Assert.Equal(0, initialQueue.CurrentIndex);
+        Assert.Equal("track-1", initialQueue.CurrentTrackId);
+
+        // Act
+        var response = await _client.PostAsync("/api/v2/queue/next", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        
+        var result = await response.Content.ReadFromJsonAsync<QueueStateDto>();
+        Assert.NotNull(result);
+        Assert.Equal(1, result.CurrentIndex);
+        Assert.Equal("track-2", result.CurrentTrackId);
+    }
+
+    [Fact]
+    public async Task NextTrack_Should_Return_404_When_Queue_Empty()
+    {
+        // Arrange
+        var token = await GetAuthTokenAsync();
+        _client.DefaultRequestHeaders.Authorization = 
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+
+        // Act
+        var response = await _client.PostAsync("/api/v2/queue/next", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Queue is empty", content);
+    }
+
+    [Fact]
+    public async Task NextTrack_Should_Return_401_When_Not_Authenticated()
+    {
+        // Arrange
+        _client.DefaultRequestHeaders.Authorization = null;
+
+        // Act
+        var response = await _client.PostAsync("/api/v2/queue/next", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task NextTrack_Should_Loop_When_RepeatAll()
+    {
+        // Arrange
+        var token = await GetAuthTokenAsync();
+        await SetupQueueWithTracksAsync(token);
+
+        // Set to last track with RepeatMode.All
+        await _client.PutAsJsonAsync("/api/v2/queue/settings", new UpdateQueueRequest 
+        { 
+            CurrentIndex = 4,
+            RepeatMode = RepeatMode.All 
+        });
+
+        // Act
+        var response = await _client.PostAsync("/api/v2/queue/next", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        
+        var result = await response.Content.ReadFromJsonAsync<QueueStateDto>();
+        Assert.NotNull(result);
+        Assert.Equal(0, result.CurrentIndex); // Looped to first
+        Assert.Equal("track-1", result.CurrentTrackId);
+    }
+
+    #endregion
+
+    #region POST /api/v2/queue/previous Tests
+
+    [Fact]
+    public async Task PreviousTrack_Should_Move_To_Previous_Track()
+    {
+        // Arrange
+        var token = await GetAuthTokenAsync();
+        await SetupQueueWithTracksAsync(token);
+        
+        // Move to track 3
+        await _client.PutAsJsonAsync("/api/v2/queue/settings", new UpdateQueueRequest { CurrentIndex = 2 });
+
+        // Act
+        var response = await _client.PostAsync("/api/v2/queue/previous", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        
+        var result = await response.Content.ReadFromJsonAsync<QueueStateDto>();
+        Assert.NotNull(result);
+        Assert.Equal(1, result.CurrentIndex);
+        Assert.Equal("track-2", result.CurrentTrackId);
+    }
+
+    [Fact]
+    public async Task PreviousTrack_Should_Return_404_When_Queue_Empty()
+    {
+        // Arrange
+        var token = await GetAuthTokenAsync();
+        _client.DefaultRequestHeaders.Authorization = 
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+
+        // Act
+        var response = await _client.PostAsync("/api/v2/queue/previous", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Queue is empty", content);
+    }
+
+    [Fact]
+    public async Task PreviousTrack_Should_Return_401_When_Not_Authenticated()
+    {
+        // Arrange
+        _client.DefaultRequestHeaders.Authorization = null;
+
+        // Act
+        var response = await _client.PostAsync("/api/v2/queue/previous", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PreviousTrack_Should_Loop_When_RepeatAll()
+    {
+        // Arrange
+        var token = await GetAuthTokenAsync();
+        await SetupQueueWithTracksAsync(token);
+
+        // Set to first track with RepeatMode.All
+        await _client.PutAsJsonAsync("/api/v2/queue/settings", new UpdateQueueRequest 
+        { 
+            CurrentIndex = 0,
+            RepeatMode = RepeatMode.All 
+        });
+
+        // Act
+        var response = await _client.PostAsync("/api/v2/queue/previous", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        
+        var result = await response.Content.ReadFromJsonAsync<QueueStateDto>();
+        Assert.NotNull(result);
+        Assert.Equal(4, result.CurrentIndex); // Looped to last
+        Assert.Equal("track-5", result.CurrentTrackId);
+    }
+
+    #endregion
+
+    #region PUT /api/v2/queue/position/{index} Tests
+
+    [Fact]
+    public async Task JumpToPosition_Should_Jump_To_Valid_Index()
+    {
+        // Arrange
+        var token = await GetAuthTokenAsync();
+        await SetupQueueWithTracksAsync(token);
+
+        // Act
+        var response = await _client.PutAsync("/api/v2/queue/position/3", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        
+        var result = await response.Content.ReadFromJsonAsync<QueueStateDto>();
+        Assert.NotNull(result);
+        Assert.Equal(3, result.CurrentIndex);
+        Assert.Equal("track-4", result.CurrentTrackId);
+    }
+
+    [Fact]
+    public async Task JumpToPosition_Should_Return_400_When_Index_Out_Of_Range()
+    {
+        // Arrange
+        var token = await GetAuthTokenAsync();
+        await SetupQueueWithTracksAsync(token);
+
+        // Act
+        var response = await _client.PutAsync("/api/v2/queue/position/10", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Index 10 is out of range", content);
+    }
+
+    [Fact]
+    public async Task JumpToPosition_Should_Return_400_When_Index_Negative()
+    {
+        // Arrange
+        var token = await GetAuthTokenAsync();
+        await SetupQueueWithTracksAsync(token);
+
+        // Act
+        var response = await _client.PutAsync("/api/v2/queue/position/-1", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task JumpToPosition_Should_Return_404_When_Queue_Empty()
+    {
+        // Arrange
+        var token = await GetAuthTokenAsync();
+        _client.DefaultRequestHeaders.Authorization = 
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+
+        // Act
+        var response = await _client.PutAsync("/api/v2/queue/position/0", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Queue is empty", content);
+    }
+
+    [Fact]
+    public async Task JumpToPosition_Should_Return_401_When_Not_Authenticated()
+    {
+        // Arrange
+        _client.DefaultRequestHeaders.Authorization = null;
+
+        // Act
+        var response = await _client.PutAsync("/api/v2/queue/position/0", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    #endregion
+}

--- a/tests/Audiarr.Tests/Services/QueueServiceTests.cs
+++ b/tests/Audiarr.Tests/Services/QueueServiceTests.cs
@@ -684,6 +684,397 @@ public class QueueServiceTests : IDisposable
 
     #endregion
 
+    #region NextTrackAsync Tests
+
+    [Fact]
+    public async Task NextTrackAsync_Should_Move_To_Next_Track()
+    {
+        // Arrange
+        var addRequest = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track-1", "track-2", "track-3", "track-4" }
+        };
+        await _queueService.AddTracksAsync(_testUserId, addRequest);
+
+        // Act
+        var result = await _queueService.NextTrackAsync(_testUserId);
+
+        // Assert
+        Assert.Equal(1, result.CurrentIndex);
+        Assert.Equal("track-2", result.CurrentTrackId);
+        Assert.Equal(4, result.TotalTracks);
+    }
+
+    [Fact]
+    public async Task NextTrackAsync_Should_Loop_To_First_When_RepeatAll_At_End()
+    {
+        // Arrange
+        var addRequest = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track-1", "track-2", "track-3" }
+        };
+        await _queueService.AddTracksAsync(_testUserId, addRequest);
+        
+        // Set to last track and enable repeat all
+        await _queueService.UpdateQueueSettingsAsync(_testUserId, new UpdateQueueRequest 
+        { 
+            CurrentIndex = 2,
+            RepeatMode = RepeatMode.All 
+        });
+
+        // Act
+        var result = await _queueService.NextTrackAsync(_testUserId);
+
+        // Assert
+        Assert.Equal(0, result.CurrentIndex);
+        Assert.Equal("track-1", result.CurrentTrackId);
+        Assert.Equal(RepeatMode.All, result.RepeatMode);
+    }
+
+    [Fact]
+    public async Task NextTrackAsync_Should_Stay_On_Last_When_RepeatNone_At_End()
+    {
+        // Arrange
+        var addRequest = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track-1", "track-2", "track-3" }
+        };
+        await _queueService.AddTracksAsync(_testUserId, addRequest);
+        
+        // Set to last track with RepeatMode.None
+        await _queueService.UpdateQueueSettingsAsync(_testUserId, new UpdateQueueRequest 
+        { 
+            CurrentIndex = 2,
+            RepeatMode = RepeatMode.None 
+        });
+
+        // Act
+        var result = await _queueService.NextTrackAsync(_testUserId);
+
+        // Assert
+        Assert.Equal(2, result.CurrentIndex); // Stays on last
+        Assert.Equal("track-3", result.CurrentTrackId);
+        Assert.Equal(RepeatMode.None, result.RepeatMode);
+    }
+
+    [Fact]
+    public async Task NextTrackAsync_Should_Stay_On_Current_When_RepeatOne()
+    {
+        // Arrange
+        var addRequest = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track-1", "track-2", "track-3" }
+        };
+        await _queueService.AddTracksAsync(_testUserId, addRequest);
+        
+        // Set repeat one mode
+        await _queueService.UpdateQueueSettingsAsync(_testUserId, new UpdateQueueRequest 
+        { 
+            CurrentIndex = 1,
+            RepeatMode = RepeatMode.One 
+        });
+
+        // Act
+        var result = await _queueService.NextTrackAsync(_testUserId);
+
+        // Assert
+        Assert.Equal(1, result.CurrentIndex); // Stays on current
+        Assert.Equal("track-2", result.CurrentTrackId);
+        Assert.Equal(RepeatMode.One, result.RepeatMode);
+    }
+
+    [Fact]
+    public async Task NextTrackAsync_Should_Throw_When_Queue_Empty()
+    {
+        // Arrange - just create empty queue
+        await _queueService.GetQueueAsync(_testUserId);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _queueService.NextTrackAsync(_testUserId));
+        Assert.Equal("Queue is empty", exception.Message);
+    }
+
+    [Fact]
+    public async Task NextTrackAsync_Should_Update_Version_And_LastActivity()
+    {
+        // Arrange
+        var addRequest = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track-1", "track-2" }
+        };
+        var initialQueue = await _queueService.AddTracksAsync(_testUserId, addRequest);
+        var initialVersion = initialQueue.Version;
+        var initialActivity = initialQueue.LastActivity;
+
+        // Wait a bit to ensure LastActivity changes
+        await Task.Delay(10);
+
+        // Act
+        var result = await _queueService.NextTrackAsync(_testUserId);
+
+        // Assert
+        Assert.Equal(initialVersion + 1, result.Version);
+        Assert.True(result.LastActivity > initialActivity);
+    }
+
+    #endregion
+
+    #region PreviousTrackAsync Tests
+
+    [Fact]
+    public async Task PreviousTrackAsync_Should_Move_To_Previous_Track()
+    {
+        // Arrange
+        var addRequest = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track-1", "track-2", "track-3", "track-4" }
+        };
+        await _queueService.AddTracksAsync(_testUserId, addRequest);
+        
+        // Set to track 3 (index 2)
+        await _queueService.UpdateQueueSettingsAsync(_testUserId, new UpdateQueueRequest { CurrentIndex = 2 });
+
+        // Act
+        var result = await _queueService.PreviousTrackAsync(_testUserId);
+
+        // Assert
+        Assert.Equal(1, result.CurrentIndex);
+        Assert.Equal("track-2", result.CurrentTrackId);
+    }
+
+    [Fact]
+    public async Task PreviousTrackAsync_Should_Loop_To_Last_When_RepeatAll_At_Start()
+    {
+        // Arrange
+        var addRequest = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track-1", "track-2", "track-3" }
+        };
+        await _queueService.AddTracksAsync(_testUserId, addRequest);
+        
+        // Set to first track with repeat all
+        await _queueService.UpdateQueueSettingsAsync(_testUserId, new UpdateQueueRequest 
+        { 
+            CurrentIndex = 0,
+            RepeatMode = RepeatMode.All 
+        });
+
+        // Act
+        var result = await _queueService.PreviousTrackAsync(_testUserId);
+
+        // Assert
+        Assert.Equal(2, result.CurrentIndex);
+        Assert.Equal("track-3", result.CurrentTrackId);
+        Assert.Equal(RepeatMode.All, result.RepeatMode);
+    }
+
+    [Fact]
+    public async Task PreviousTrackAsync_Should_Stay_On_First_When_RepeatNone_At_Start()
+    {
+        // Arrange
+        var addRequest = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track-1", "track-2", "track-3" }
+        };
+        await _queueService.AddTracksAsync(_testUserId, addRequest);
+        
+        // Already at first with RepeatMode.None (default)
+        await _queueService.UpdateQueueSettingsAsync(_testUserId, new UpdateQueueRequest 
+        { 
+            CurrentIndex = 0,
+            RepeatMode = RepeatMode.None 
+        });
+
+        // Act
+        var result = await _queueService.PreviousTrackAsync(_testUserId);
+
+        // Assert
+        Assert.Equal(0, result.CurrentIndex); // Stays on first
+        Assert.Equal("track-1", result.CurrentTrackId);
+        Assert.Equal(RepeatMode.None, result.RepeatMode);
+    }
+
+    [Fact]
+    public async Task PreviousTrackAsync_Should_Stay_On_Current_When_RepeatOne()
+    {
+        // Arrange
+        var addRequest = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track-1", "track-2", "track-3" }
+        };
+        await _queueService.AddTracksAsync(_testUserId, addRequest);
+        
+        // Set repeat one mode
+        await _queueService.UpdateQueueSettingsAsync(_testUserId, new UpdateQueueRequest 
+        { 
+            CurrentIndex = 1,
+            RepeatMode = RepeatMode.One 
+        });
+
+        // Act
+        var result = await _queueService.PreviousTrackAsync(_testUserId);
+
+        // Assert
+        Assert.Equal(1, result.CurrentIndex); // Stays on current
+        Assert.Equal("track-2", result.CurrentTrackId);
+        Assert.Equal(RepeatMode.One, result.RepeatMode);
+    }
+
+    [Fact]
+    public async Task PreviousTrackAsync_Should_Throw_When_Queue_Empty()
+    {
+        // Arrange - just create empty queue
+        await _queueService.GetQueueAsync(_testUserId);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _queueService.PreviousTrackAsync(_testUserId));
+        Assert.Equal("Queue is empty", exception.Message);
+    }
+
+    [Fact]
+    public async Task PreviousTrackAsync_Should_Update_Version_And_LastActivity()
+    {
+        // Arrange
+        var addRequest = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track-1", "track-2", "track-3" }
+        };
+        await _queueService.AddTracksAsync(_testUserId, addRequest);
+        await _queueService.UpdateQueueSettingsAsync(_testUserId, new UpdateQueueRequest { CurrentIndex = 2 });
+        
+        var queueBefore = await _queueService.GetQueueAsync(_testUserId);
+        var initialVersion = queueBefore.Version;
+        var initialActivity = queueBefore.LastActivity;
+
+        // Wait a bit to ensure LastActivity changes
+        await Task.Delay(10);
+
+        // Act
+        var result = await _queueService.PreviousTrackAsync(_testUserId);
+
+        // Assert
+        Assert.Equal(initialVersion + 1, result.Version);
+        Assert.True(result.LastActivity > initialActivity);
+    }
+
+    #endregion
+
+    #region JumpToPositionAsync Tests
+
+    [Fact]
+    public async Task JumpToPositionAsync_Should_Jump_To_Valid_Position()
+    {
+        // Arrange
+        var addRequest = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track-1", "track-2", "track-3", "track-4", "track-5" }
+        };
+        await _queueService.AddTracksAsync(_testUserId, addRequest);
+
+        // Act
+        var result = await _queueService.JumpToPositionAsync(_testUserId, 3);
+
+        // Assert
+        Assert.Equal(3, result.CurrentIndex);
+        Assert.Equal("track-4", result.CurrentTrackId);
+    }
+
+    [Fact]
+    public async Task JumpToPositionAsync_Should_Throw_When_Index_Negative()
+    {
+        // Arrange
+        var addRequest = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track-1", "track-2" }
+        };
+        await _queueService.AddTracksAsync(_testUserId, addRequest);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => _queueService.JumpToPositionAsync(_testUserId, -1));
+        Assert.Contains("Index -1 is out of range", exception.Message);
+    }
+
+    [Fact]
+    public async Task JumpToPositionAsync_Should_Throw_When_Index_Too_Large()
+    {
+        // Arrange
+        var addRequest = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track-1", "track-2", "track-3" }
+        };
+        await _queueService.AddTracksAsync(_testUserId, addRequest);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => _queueService.JumpToPositionAsync(_testUserId, 5));
+        Assert.Contains("Index 5 is out of range", exception.Message);
+        Assert.Contains("Queue has 3 tracks", exception.Message);
+    }
+
+    [Fact]
+    public async Task JumpToPositionAsync_Should_Throw_When_Queue_Empty()
+    {
+        // Arrange - just create empty queue
+        await _queueService.GetQueueAsync(_testUserId);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _queueService.JumpToPositionAsync(_testUserId, 0));
+        Assert.Equal("Queue is empty", exception.Message);
+    }
+
+    [Fact]
+    public async Task JumpToPositionAsync_Should_Update_CurrentTrack_And_Index()
+    {
+        // Arrange
+        var addRequest = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track-1", "track-2", "track-3", "track-4" }
+        };
+        await _queueService.AddTracksAsync(_testUserId, addRequest);
+
+        // Jump to different positions
+        var result1 = await _queueService.JumpToPositionAsync(_testUserId, 2);
+        Assert.Equal(2, result1.CurrentIndex);
+        Assert.Equal("track-3", result1.CurrentTrackId);
+
+        var result2 = await _queueService.JumpToPositionAsync(_testUserId, 0);
+        Assert.Equal(0, result2.CurrentIndex);
+        Assert.Equal("track-1", result2.CurrentTrackId);
+
+        var result3 = await _queueService.JumpToPositionAsync(_testUserId, 3);
+        Assert.Equal(3, result3.CurrentIndex);
+        Assert.Equal("track-4", result3.CurrentTrackId);
+    }
+
+    [Fact]
+    public async Task JumpToPositionAsync_Should_Update_Version_And_LastActivity()
+    {
+        // Arrange
+        var addRequest = new AddToQueueRequest
+        {
+            TrackIds = new List<string> { "track-1", "track-2", "track-3" }
+        };
+        var initialQueue = await _queueService.AddTracksAsync(_testUserId, addRequest);
+        var initialVersion = initialQueue.Version;
+        var initialActivity = initialQueue.LastActivity;
+
+        // Wait a bit to ensure LastActivity changes
+        await Task.Delay(10);
+
+        // Act
+        var result = await _queueService.JumpToPositionAsync(_testUserId, 2);
+
+        // Assert
+        Assert.Equal(initialVersion + 1, result.Version);
+        Assert.True(result.LastActivity > initialActivity);
+    }
+
+    #endregion
+
     public void Dispose()
     {
         _context?.Dispose();


### PR DESCRIPTION
- Add NextTrackAsync, PreviousTrackAsync, and JumpToPositionAsync methods to IQueueService
- Implement queue navigation logic with proper RepeatMode handling (None, One, All)
- Add PUT /api/v2/queue/settings endpoint for updating repeat/shuffle settings
- Add POST /api/v2/queue/next endpoint to skip to next track
- Add POST /api/v2/queue/previous endpoint to go to previous track
- Add PUT /api/v2/queue/position/{index} endpoint to jump to specific track
- Fix RepeatMode.One to always stay on current track
- Add comprehensive unit tests for all new service methods (18 tests)
- Add integration tests for all new endpoints
- Handle edge cases: empty queue (404), invalid index (400), authentication (401)
- Update LastActivity and Version for all queue operations

All tests passing. Verified with Docker deployment.