### PR TITLE
fix: Convert PositionFloat from decimal to double to resolve SQLite o…

### DIFF
--- a/docs/API_MODELS.md
+++ b/docs/API_MODELS.md
@@ -1204,7 +1204,7 @@ Track information within a playlist context.
 | year | integer | Release year |
 | filePath | string | File system path to audio file |
 | position | integer | Integer position in playlist (0-based) |
-| positionFloat | decimal | Decimal position for precise ordering |
+| positionFloat | double | Floating-point position for precise ordering |
 | addedAt | string | ISO 8601 timestamp when track was added |
 | addedBy | string | Username who added the track |
 
@@ -1303,7 +1303,7 @@ Individual track reorder specification.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | trackId | string | Yes | Track ID to reorder |
-| newPosition | decimal | Yes | New decimal position in playlist |
+| newPosition | double | Yes | New floating-point position in playlist |
 
 ### UpdatePlaylistImageRequest
 Request to update playlist cover image.

--- a/src/Audiarr.Api/Endpoints/PlaylistEndpoints.cs
+++ b/src/Audiarr.Api/Endpoints/PlaylistEndpoints.cs
@@ -180,7 +180,7 @@ public static class PlaylistEndpoints
                     .Where(t => request.InitialTrackIds.Contains(t.Id))
                     .ToListAsync();
 
-                decimal position = 0;
+                double position = 0;
                 foreach (var trackId in request.InitialTrackIds)
                 {
                     if (tracks.Any(t => t.Id == trackId))
@@ -414,7 +414,7 @@ public static class PlaylistEndpoints
             var existingTrackIds = playlist.PlaylistTracks.Select(pt => pt.TrackId).ToHashSet();
 
             // Determine starting position
-            decimal startPosition;
+            double startPosition;
             if (request.Position.HasValue && request.Position.Value >= 0)
             {
                 // Insert at specific position

--- a/src/Audiarr.Core/DTOs/PlaylistTrackDto.cs
+++ b/src/Audiarr.Core/DTOs/PlaylistTrackDto.cs
@@ -17,7 +17,7 @@ public class PlaylistTrackDto
 
     // Playlist-specific fields
     public int Position { get; set; }
-    public decimal PositionFloat { get; set; }
+    public double PositionFloat { get; set; }
     public DateTime AddedAt { get; set; }
     public string? AddedBy { get; set; }
 }

--- a/src/Audiarr.Core/DTOs/Requests/PlaylistRequests.cs
+++ b/src/Audiarr.Core/DTOs/Requests/PlaylistRequests.cs
@@ -57,7 +57,7 @@ public record TrackReorderItem
     public required string TrackId { get; init; }
 
     [Required]
-    public required decimal NewPosition { get; init; }
+    public required double NewPosition { get; init; }
 }
 
 public record UpdatePlaylistImageRequest

--- a/src/Audiarr.Core/Entities/PlaylistTrack.cs
+++ b/src/Audiarr.Core/Entities/PlaylistTrack.cs
@@ -5,7 +5,7 @@ public class PlaylistTrack
     public required string PlaylistId { get; set; }
     public required string TrackId { get; set; }
     public int Position { get; set; }
-    public decimal PositionFloat { get; set; } = 0; // For conflict-free reordering
+    public double PositionFloat { get; set; } = 0; // For conflict-free reordering
     public DateTime AddedAt { get; set; } = DateTime.UtcNow;
     public string? AddedBy { get; set; } // Username who added the track (for future collaborative features)
 

--- a/src/Audiarr.Data/Context/AudiarrContext.cs
+++ b/src/Audiarr.Data/Context/AudiarrContext.cs
@@ -123,8 +123,7 @@ public class AudiarrContext : DbContext
             entity.HasIndex(e => e.AddedAt);
 
             // Property configurations
-            entity.Property(e => e.PositionFloat)
-                .HasPrecision(18, 6);
+            // PositionFloat is now double, no precision configuration needed
             entity.Property(e => e.AddedBy)
                 .HasMaxLength(50);
             entity.Property(e => e.AddedAt)

--- a/src/Audiarr.Data/Migrations/20250911015606_ChangePositionFloatToDouble.Designer.cs
+++ b/src/Audiarr.Data/Migrations/20250911015606_ChangePositionFloatToDouble.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Audiarr.Data.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Audiarr.Data.Migrations
 {
     [DbContext(typeof(AudiarrContext))]
-    partial class AudiarrContextModelSnapshot : ModelSnapshot
+    [Migration("20250911015606_ChangePositionFloatToDouble")]
+    partial class ChangePositionFloatToDouble
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.0");

--- a/src/Audiarr.Data/Migrations/20250911015606_ChangePositionFloatToDouble.cs
+++ b/src/Audiarr.Data/Migrations/20250911015606_ChangePositionFloatToDouble.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Audiarr.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangePositionFloatToDouble : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<double>(
+                name: "PositionFloat",
+                table: "PlaylistTracks",
+                type: "REAL",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "TEXT",
+                oldPrecision: 18,
+                oldScale: 6);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "PositionFloat",
+                table: "PlaylistTracks",
+                type: "TEXT",
+                precision: 18,
+                scale: 6,
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "REAL");
+        }
+    }
+}

--- a/tests/Audiarr.Tests/DTOs/PlaylistDetailsDtoTests.cs
+++ b/tests/Audiarr.Tests/DTOs/PlaylistDetailsDtoTests.cs
@@ -62,7 +62,7 @@ public class PlaylistDetailsDtoTests
             Title = "Song 1",
             ArtistName = "Artist 1",
             Position = 0,
-            PositionFloat = 0m
+            PositionFloat = 0
         };
         var track2 = new PlaylistTrackDto
         {
@@ -70,7 +70,7 @@ public class PlaylistDetailsDtoTests
             Title = "Song 2",
             ArtistName = "Artist 2",
             Position = 1,
-            PositionFloat = 1m
+            PositionFloat = 1
         };
 
         // Act

--- a/tests/Audiarr.Tests/DTOs/PlaylistTrackDtoTests.cs
+++ b/tests/Audiarr.Tests/DTOs/PlaylistTrackDtoTests.cs
@@ -25,7 +25,7 @@ public class PlaylistTrackDtoTests
         Assert.Null(dto.Year);
         Assert.Equal(string.Empty, dto.FilePath);
         Assert.Equal(0, dto.Position);
-        Assert.Equal(0m, dto.PositionFloat);
+        Assert.Equal(0, dto.PositionFloat);
         Assert.Equal(default(DateTime), dto.AddedAt);
         Assert.Null(dto.AddedBy);
     }
@@ -51,7 +51,7 @@ public class PlaylistTrackDtoTests
         dto.Year = 2024;
         dto.FilePath = "/music/test.mp3";
         dto.Position = 3;
-        dto.PositionFloat = 3.5m;
+        dto.PositionFloat = 3.5;
         dto.AddedAt = testDate;
         dto.AddedBy = "testuser";
 
@@ -69,7 +69,7 @@ public class PlaylistTrackDtoTests
         Assert.Equal(2024, dto.Year);
         Assert.Equal("/music/test.mp3", dto.FilePath);
         Assert.Equal(3, dto.Position);
-        Assert.Equal(3.5m, dto.PositionFloat);
+        Assert.Equal(3.5, dto.PositionFloat);
         Assert.Equal(testDate, dto.AddedAt);
         Assert.Equal("testuser", dto.AddedBy);
     }
@@ -91,7 +91,7 @@ public class PlaylistTrackDtoTests
 
             // Playlist-specific information
             Position = 5,
-            PositionFloat = 5.25m,
+            PositionFloat = 5.25,
             AddedAt = DateTime.UtcNow,
             AddedBy = "user123"
         };
@@ -100,7 +100,7 @@ public class PlaylistTrackDtoTests
         Assert.NotEqual(string.Empty, dto.TrackId);
         Assert.NotEqual(string.Empty, dto.Title);
         Assert.NotEqual(0, dto.Position);
-        Assert.NotEqual(0m, dto.PositionFloat);
+        Assert.NotEqual(0.0, dto.PositionFloat);
         Assert.NotNull(dto.AddedBy);
     }
 
@@ -110,7 +110,7 @@ public class PlaylistTrackDtoTests
     [InlineData(1, 1.5)]
     [InlineData(2, 1.75)]
     [InlineData(100, 99.999)]
-    public void PlaylistTrackDto_PositionFields_CanHoldDifferentValues(int position, decimal positionFloat)
+    public void PlaylistTrackDto_PositionFields_CanHoldDifferentValues(int position, double positionFloat)
     {
         // Arrange & Act
         var dto = new PlaylistTrackDto
@@ -144,12 +144,12 @@ public class PlaylistTrackDtoTests
         // This test demonstrates how PositionFloat can be used for reordering
 
         // Arrange - Create three tracks in order
-        var track1 = new PlaylistTrackDto { TrackId = "1", Position = 0, PositionFloat = 1.0m };
-        var track2 = new PlaylistTrackDto { TrackId = "2", Position = 1, PositionFloat = 2.0m };
-        var track3 = new PlaylistTrackDto { TrackId = "3", Position = 2, PositionFloat = 3.0m };
+        var track1 = new PlaylistTrackDto { TrackId = "1", Position = 0, PositionFloat = 1.0 };
+        var track2 = new PlaylistTrackDto { TrackId = "2", Position = 1, PositionFloat = 2.0 };
+        var track3 = new PlaylistTrackDto { TrackId = "3", Position = 2, PositionFloat = 3.0 };
 
         // Act - Move track3 between track1 and track2
-        track3.PositionFloat = 1.5m;
+        track3.PositionFloat = 1.5;
 
         // Assert - track3's PositionFloat is now between track1 and track2
         Assert.True(track3.PositionFloat > track1.PositionFloat);

--- a/tests/Audiarr.Tests/DTOs/Requests/PlaylistRequestsTests.cs
+++ b/tests/Audiarr.Tests/DTOs/Requests/PlaylistRequestsTests.cs
@@ -164,9 +164,9 @@ public class PlaylistRequestsTests
         {
             Tracks = new List<TrackReorderItem>
             {
-                new() { TrackId = "track1", NewPosition = 0.5m },
-                new() { TrackId = "track2", NewPosition = 1.5m },
-                new() { TrackId = "track3", NewPosition = 2.5m }
+                new() { TrackId = "track1", NewPosition = 0.5 },
+                new() { TrackId = "track2", NewPosition = 1.5 },
+                new() { TrackId = "track3", NewPosition = 2.5 }
             }
         };
 
@@ -188,12 +188,12 @@ public class PlaylistRequestsTests
         var item = new TrackReorderItem
         {
             TrackId = "track123",
-            NewPosition = 5.25m
+            NewPosition = 5.25
         };
 
         // Act & Assert
         Assert.Equal("track123", item.TrackId);
-        Assert.Equal(5.25m, item.NewPosition);
+        Assert.Equal(5.25, item.NewPosition);
     }
 
     [Fact]

--- a/tests/Audiarr.Tests/Data/AudiarrContextTests.cs
+++ b/tests/Audiarr.Tests/Data/AudiarrContextTests.cs
@@ -134,13 +134,10 @@ public class AudiarrContextTests : IDisposable
 
         Assert.NotNull(entityType);
 
-        // Check PositionFloat precision
+        // Check PositionFloat is double type (no precision needed)
         var positionFloatProperty = entityType.FindProperty("PositionFloat");
         Assert.NotNull(positionFloatProperty);
-        var precision = positionFloatProperty.GetPrecision();
-        var scale = positionFloatProperty.GetScale();
-        Assert.Equal(18, precision);
-        Assert.Equal(6, scale);
+        Assert.Equal(typeof(double), positionFloatProperty.ClrType);
 
         // Check AddedBy max length
         var addedByProperty = entityType.FindProperty("AddedBy");

--- a/tests/Audiarr.Tests/Endpoints/PlaylistEndpointsTests.cs
+++ b/tests/Audiarr.Tests/Endpoints/PlaylistEndpointsTests.cs
@@ -81,8 +81,8 @@ public class PlaylistEndpointsTests
         {
             Tracks = new List<TrackReorderItem>
             {
-                new() { TrackId = "track1", NewPosition = 0.5m },
-                new() { TrackId = "track2", NewPosition = 1.5m }
+                new() { TrackId = "track1", NewPosition = 0.5 },
+                new() { TrackId = "track2", NewPosition = 1.5 }
             }
         };
 
@@ -90,7 +90,7 @@ public class PlaylistEndpointsTests
         Assert.NotNull(validRequest.Tracks);
         Assert.Equal(2, validRequest.Tracks.Count);
         Assert.Equal("track1", validRequest.Tracks[0].TrackId);
-        Assert.Equal(0.5m, validRequest.Tracks[0].NewPosition);
+        Assert.Equal(0.5, validRequest.Tracks[0].NewPosition);
     }
 
     [Fact]
@@ -223,18 +223,18 @@ public class PlaylistEndpointsTests
         {
             Tracks = new List<TrackReorderItem>
             {
-                new() { TrackId = "track1", NewPosition = 0.5m },
-                new() { TrackId = "track2", NewPosition = 1.5m },
-                new() { TrackId = "track3", NewPosition = 2.0m },
-                new() { TrackId = "track4", NewPosition = 2.5m }
+                new() { TrackId = "track1", NewPosition = 0.5 },
+                new() { TrackId = "track2", NewPosition = 1.5 },
+                new() { TrackId = "track3", NewPosition = 2.0 },
+                new() { TrackId = "track4", NewPosition = 2.5 }
             }
         };
 
         // Act & Assert
         Assert.NotNull(request.Tracks);
         Assert.Equal(4, request.Tracks.Count);
-        Assert.Equal(0.5m, request.Tracks[0].NewPosition);
-        Assert.Equal(2.5m, request.Tracks[3].NewPosition);
+        Assert.Equal(0.5, request.Tracks[0].NewPosition);
+        Assert.Equal(2.5, request.Tracks[3].NewPosition);
     }
 
     [Fact]
@@ -246,11 +246,11 @@ public class PlaylistEndpointsTests
             Tracks = new List<TrackReorderItem>
             {
                 // Move track between position 1 and 2
-                new() { TrackId = "trackA", NewPosition = 1.5m },
+                new() { TrackId = "trackA", NewPosition = 1.5 },
                 // Move track between position 1 and the newly placed track
-                new() { TrackId = "trackB", NewPosition = 1.25m },
+                new() { TrackId = "trackB", NewPosition = 1.25 },
                 // Move track between the two newly placed tracks
-                new() { TrackId = "trackC", NewPosition = 1.375m }
+                new() { TrackId = "trackC", NewPosition = 1.375 }
             }
         };
 
@@ -260,9 +260,9 @@ public class PlaylistEndpointsTests
 
         // Verify positions maintain proper ordering
         var sortedPositions = request.Tracks.Select(t => t.NewPosition).OrderBy(p => p).ToList();
-        Assert.Equal(1.25m, sortedPositions[0]);
-        Assert.Equal(1.375m, sortedPositions[1]);
-        Assert.Equal(1.5m, sortedPositions[2]);
+        Assert.Equal(1.25, sortedPositions[0]);
+        Assert.Equal(1.375, sortedPositions[1]);
+        Assert.Equal(1.5, sortedPositions[2]);
     }
 
     [Fact]

--- a/tests/Audiarr.Tests/Entities/PlaylistTrackTests.cs
+++ b/tests/Audiarr.Tests/Entities/PlaylistTrackTests.cs
@@ -19,7 +19,7 @@ public class PlaylistTrackTests
         Assert.Equal("playlist123", playlistTrack.PlaylistId);
         Assert.Equal("track456", playlistTrack.TrackId);
         Assert.Equal(0, playlistTrack.Position);
-        Assert.Equal(0m, playlistTrack.PositionFloat);
+        Assert.Equal(0, playlistTrack.PositionFloat);
         Assert.Null(playlistTrack.AddedBy);
 
         // AddedAt should be close to current UTC time (within 1 second)
@@ -39,8 +39,8 @@ public class PlaylistTrackTests
         };
 
         // Assert
-        Assert.Equal(0m, playlistTrack.PositionFloat);
-        Assert.IsType<decimal>(playlistTrack.PositionFloat);
+        Assert.Equal(0, playlistTrack.PositionFloat);
+        Assert.IsType<double>(playlistTrack.PositionFloat);
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public class PlaylistTrackTests
 
         // Act
         playlistTrack.Position = 5;
-        playlistTrack.PositionFloat = 5.5m;
+        playlistTrack.PositionFloat = 5.5;
         playlistTrack.AddedAt = testDate;
         playlistTrack.AddedBy = "testuser";
 
@@ -87,7 +87,7 @@ public class PlaylistTrackTests
         Assert.Equal("playlist123", playlistTrack.PlaylistId);
         Assert.Equal("track456", playlistTrack.TrackId);
         Assert.Equal(5, playlistTrack.Position);
-        Assert.Equal(5.5m, playlistTrack.PositionFloat);
+        Assert.Equal(5.5, playlistTrack.PositionFloat);
         Assert.Equal(testDate, playlistTrack.AddedAt);
         Assert.Equal("testuser", playlistTrack.AddedBy);
     }
@@ -99,7 +99,7 @@ public class PlaylistTrackTests
     [InlineData(2, 1.75)]
     [InlineData(100, 99.999)]
     [InlineData(int.MaxValue, 2147483647.5)]
-    public void PlaylistTrack_PositionFields_CanHoldDifferentValues(int position, decimal positionFloat)
+    public void PlaylistTrack_PositionFields_CanHoldDifferentValues(int position, double positionFloat)
     {
         // Arrange
         var playlistTrack = new PlaylistTrack
@@ -127,7 +127,7 @@ public class PlaylistTrackTests
             PlaylistId = "playlist123",
             TrackId = "track1",
             Position = 1,
-            PositionFloat = 1.0m
+            PositionFloat = 1.0
         };
 
         var track2 = new PlaylistTrack
@@ -135,7 +135,7 @@ public class PlaylistTrackTests
             PlaylistId = "playlist123",
             TrackId = "track2",
             Position = 2,
-            PositionFloat = 2.0m
+            PositionFloat = 2.0
         };
 
         // Act - Insert a track between track1 and track2
@@ -144,7 +144,7 @@ public class PlaylistTrackTests
             PlaylistId = "playlist123",
             TrackId = "track3",
             Position = 1, // Could still be 1, but...
-            PositionFloat = 1.5m // This allows precise positioning
+            PositionFloat = 1.5 // This allows precise positioning
         };
 
         // Assert - The inserted track's PositionFloat is between the other two
@@ -215,11 +215,11 @@ public class PlaylistTrackTests
         // without needing to reindex
 
         // Arrange - Start with two tracks
-        decimal position1 = 1.0m;
-        decimal position2 = 2.0m;
+        double position1 = 1.0;
+        double position2 = 2.0;
 
         // Act - Simulate multiple insertions between them
-        var positions = new List<decimal>();
+        var positions = new List<double>();
         for (int i = 0; i < 10; i++)
         {
             var newPosition = (position1 + position2) / 2;
@@ -229,7 +229,7 @@ public class PlaylistTrackTests
 
         // Assert - All positions are unique and between 1.0 and 2.0
         Assert.Equal(10, positions.Count);
-        Assert.All(positions, p => Assert.True(p > 1.0m && p < 2.0m));
+        Assert.All(positions, p => Assert.True(p > 1.0 && p < 2.0));
         Assert.Equal(positions.Count, positions.Distinct().Count()); // All unique
 
         // Verify they're in descending order (each new one is closer to 1.0)


### PR DESCRIPTION
…rdering issue

- Changed PlaylistTrack.PositionFloat from decimal to double type
- Removed precision configuration from database context
- Updated all DTOs and request models to use double
- Fixed all tests to use double literals instead of decimal
- Created migration to update database schema
- Updated API documentation to reflect type change

This resolves issue #84 where SQLite was unable to properly order by decimal values in ORDER BY clauses. The double type is properly supported by SQLite and maintains the fractional positioning system for conflict-free reordering.