### PR TITLE
feat: Multi-valued tags support - API endpoints and DTOs

### DIFF
--- a/src/Audiarr.Api/Endpoints/AlbumEndpoints.cs
+++ b/src/Audiarr.Api/Endpoints/AlbumEndpoints.cs
@@ -335,11 +335,21 @@ public static class AlbumEndpoints
         dto.ArtistIds = allArtists.Select(a => a.Id).ToArray();
         dto.ArtistNames = allArtists.Select(a => a.Name).ToArray();
 
-        // If no artists in many-to-many relationship, fallback to single-value field
-        if (dto.ArtistIds.Length == 0 && !string.IsNullOrEmpty(album.ArtistId))
+        // Ensure primary artist from single-value field is included first, even if not in many-to-many relationship
+        if (!string.IsNullOrEmpty(album.ArtistId))
         {
-            dto.ArtistIds = new[] { album.ArtistId };
-            dto.ArtistNames = new[] { album.Artist?.Name ?? string.Empty };
+            if (dto.ArtistIds.Length == 0)
+            {
+                // No artists in many-to-many relationship, use single-value field
+                dto.ArtistIds = new[] { album.ArtistId };
+                dto.ArtistNames = new[] { album.Artist?.Name ?? string.Empty };
+            }
+            else if (!dto.ArtistIds.Contains(album.ArtistId))
+            {
+                // Primary artist exists but is not in many-to-many relationship, prepend it
+                dto.ArtistIds = new[] { album.ArtistId }.Concat(dto.ArtistIds).ToArray();
+                dto.ArtistNames = new[] { album.Artist?.Name ?? string.Empty }.Concat(dto.ArtistNames).ToArray();
+            }
         }
 
         // Populate genre arrays: Primary first (matching dto.Genre name), then others alphabetically
@@ -358,10 +368,19 @@ public static class AlbumEndpoints
 
         dto.Genres = allGenres.Select(g => g.Name).ToArray();
 
-        // If no genres in many-to-many relationship, fallback to single-value field
-        if (dto.Genres.Length == 0 && !string.IsNullOrEmpty(dto.Genre))
+        // Ensure primary genre from single-value field is included first, even if not in many-to-many relationship
+        if (!string.IsNullOrEmpty(dto.Genre))
         {
-            dto.Genres = new[] { dto.Genre };
+            if (dto.Genres.Length == 0)
+            {
+                // No genres in many-to-many relationship, use single-value field
+                dto.Genres = new[] { dto.Genre };
+            }
+            else if (!dto.Genres.Contains(dto.Genre))
+            {
+                // Primary genre exists but is not in many-to-many relationship, prepend it
+                dto.Genres = new[] { dto.Genre }.Concat(dto.Genres).ToArray();
+            }
         }
     }
 
@@ -387,11 +406,21 @@ public static class AlbumEndpoints
         dto.ArtistIds = allArtists.Select(a => a.Id).ToArray();
         dto.ArtistNames = allArtists.Select(a => a.Name).ToArray();
 
-        // If no artists in many-to-many relationship, fallback to single-value field
-        if (dto.ArtistIds.Length == 0 && !string.IsNullOrEmpty(track.ArtistId))
+        // Ensure primary artist from single-value field is included first, even if not in many-to-many relationship
+        if (!string.IsNullOrEmpty(track.ArtistId))
         {
-            dto.ArtistIds = new[] { track.ArtistId };
-            dto.ArtistNames = new[] { track.Artist?.Name ?? string.Empty };
+            if (dto.ArtistIds.Length == 0)
+            {
+                // No artists in many-to-many relationship, use single-value field
+                dto.ArtistIds = new[] { track.ArtistId };
+                dto.ArtistNames = new[] { track.Artist?.Name ?? string.Empty };
+            }
+            else if (!dto.ArtistIds.Contains(track.ArtistId))
+            {
+                // Primary artist exists but is not in many-to-many relationship, prepend it
+                dto.ArtistIds = new[] { track.ArtistId }.Concat(dto.ArtistIds).ToArray();
+                dto.ArtistNames = new[] { track.Artist?.Name ?? string.Empty }.Concat(dto.ArtistNames).ToArray();
+            }
         }
 
         // Populate genre arrays: Primary first (matching Track.Genre name), then others alphabetically
@@ -409,10 +438,19 @@ public static class AlbumEndpoints
 
         dto.Genres = allGenres.Select(g => g.Name).ToArray();
 
-        // If no genres in many-to-many relationship, fallback to single-value field
-        if (dto.Genres.Length == 0 && !string.IsNullOrEmpty(track.Genre))
+        // Ensure primary genre from single-value field is included first, even if not in many-to-many relationship
+        if (!string.IsNullOrEmpty(track.Genre))
         {
-            dto.Genres = new[] { track.Genre };
+            if (dto.Genres.Length == 0)
+            {
+                // No genres in many-to-many relationship, use single-value field
+                dto.Genres = new[] { track.Genre };
+            }
+            else if (!dto.Genres.Contains(track.Genre))
+            {
+                // Primary genre exists but is not in many-to-many relationship, prepend it
+                dto.Genres = new[] { track.Genre }.Concat(dto.Genres).ToArray();
+            }
         }
     }
 

--- a/src/Audiarr.Api/Endpoints/AlbumEndpoints.cs
+++ b/src/Audiarr.Api/Endpoints/AlbumEndpoints.cs
@@ -301,7 +301,7 @@ public static class AlbumEndpoints
 
     /// <summary>
     /// Populates multi-valued tag arrays (ArtistIds, ArtistNames, Genres) in an AlbumDto from an Album entity.
-    /// Ensures primary artist/genre (matching Album.ArtistId and Album.Genre) appears first in arrays.
+    /// Ensures primary artist/genre (matching Album.ArtistId and dto.Genre) appears first in arrays.
     /// </summary>
     private static void PopulateMultiValuedTags(Album album, AlbumDto dto)
     {
@@ -328,11 +328,12 @@ public static class AlbumEndpoints
             dto.ArtistNames = new[] { album.Artist?.Name ?? string.Empty };
         }
 
-        // Populate genre arrays: Primary first (matching Album.Genre name), then others alphabetically
+        // Populate genre arrays: Primary first (matching dto.Genre name), then others alphabetically
+        // Use dto.Genre (which is set from first track's genre) instead of album.Genre to ensure consistency
         var primaryGenre = album.AlbumGenres
-            .FirstOrDefault(ag => ag.Genre.Name == album.Genre)?.Genre;
+            .FirstOrDefault(ag => ag.Genre.Name == dto.Genre)?.Genre;
         var otherGenres = album.AlbumGenres
-            .Where(ag => ag.Genre.Name != album.Genre)
+            .Where(ag => ag.Genre.Name != dto.Genre)
             .Select(ag => ag.Genre)
             .OrderBy(g => g.Name)
             .ToList();
@@ -344,9 +345,9 @@ public static class AlbumEndpoints
         dto.Genres = allGenres.Select(g => g.Name).ToArray();
 
         // If no genres in many-to-many relationship, fallback to single-value field
-        if (dto.Genres.Length == 0 && !string.IsNullOrEmpty(album.Genre))
+        if (dto.Genres.Length == 0 && !string.IsNullOrEmpty(dto.Genre))
         {
-            dto.Genres = new[] { album.Genre };
+            dto.Genres = new[] { dto.Genre };
         }
     }
 

--- a/src/Audiarr.Api/Endpoints/AlbumEndpoints.cs
+++ b/src/Audiarr.Api/Endpoints/AlbumEndpoints.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Audiarr.Data.Context;
 using Audiarr.Core.DTOs;
+using Audiarr.Core.Entities;
 
 namespace Audiarr.Api.Endpoints;
 
@@ -22,6 +23,10 @@ public static class AlbumEndpoints
             var query = db.Albums
                 .Include(a => a.Artist)
                 .Include(a => a.Tracks)
+                .Include(a => a.AlbumArtists)
+                    .ThenInclude(aa => aa.Artist)
+                .Include(a => a.AlbumGenres)
+                    .ThenInclude(ag => ag.Genre)
                 .OrderBy(a => a.Artist.SortName ?? a.Artist.Name)
                 .ThenBy(a => a.Year)
                 .ThenBy(a => a.Title);
@@ -48,6 +53,12 @@ public static class AlbumEndpoints
                 ReleaseDate = a.ReleaseDate
             }).ToList();
 
+            // Populate multi-valued tag arrays
+            foreach (var album in albumsData.Zip(albums, (a, dto) => new { Album = a, Dto = dto }))
+            {
+                PopulateMultiValuedTags(album.Album, album.Dto);
+            }
+
             return Results.Ok(new
             {
                 data = albums,
@@ -69,6 +80,10 @@ public static class AlbumEndpoints
             var albumData = await db.Albums
                 .Include(a => a.Artist)
                 .Include(a => a.Tracks)
+                .Include(a => a.AlbumArtists)
+                    .ThenInclude(aa => aa.Artist)
+                .Include(a => a.AlbumGenres)
+                    .ThenInclude(ag => ag.Genre)
                 .Where(a => a.Id == id)
                 .FirstOrDefaultAsync();
 
@@ -99,7 +114,8 @@ public static class AlbumEndpoints
                 .ThenBy(t => t.TrackNumber)
                 .ToList();
 
-            var result = new
+            // Create AlbumDto and populate multi-valued tags
+            var albumDto = new AlbumDto
             {
                 Id = albumData.Id,
                 Title = albumData.Title,
@@ -109,9 +125,30 @@ public static class AlbumEndpoints
                 TrackCount = albumData.Tracks.Count,
                 Genre = albumData.Tracks.Select(t => t.Genre).FirstOrDefault(),
                 CoverArtPath = albumData.CoverArtPath,
-                ReleaseDate = albumData.ReleaseDate,
+                ReleaseDate = albumData.ReleaseDate
+            };
+
+            PopulateMultiValuedTags(albumData, albumDto);
+
+            var result = new
+            {
+                albumDto.Id,
+                albumDto.Title,
+                albumDto.ArtistId,
+                albumDto.ArtistName,
+                albumDto.Year,
+                albumDto.TrackCount,
+                albumDto.Genre,
+                albumDto.CoverArtPath,
+                albumDto.ReleaseDate,
                 TotalDurationMs = albumData.Tracks.Sum(t => t.DurationMs),
-                Tracks = tracks
+                Tracks = tracks,
+                // Multi-valued tag arrays
+                albumDto.ArtistIds,
+                albumDto.ArtistNames,
+                albumDto.Genres,
+                albumDto.PrimaryArtistId,
+                albumDto.PrimaryArtistName
             };
 
             return Results.Ok(result);
@@ -226,6 +263,10 @@ public static class AlbumEndpoints
             var albumsData = await db.Albums
                 .Include(a => a.Artist)
                 .Include(a => a.Tracks)
+                .Include(a => a.AlbumArtists)
+                    .ThenInclude(aa => aa.Artist)
+                .Include(a => a.AlbumGenres)
+                    .ThenInclude(ag => ag.Genre)
                 .OrderByDescending(a => a.AddedDate)
                 .Take(limit)
                 .ToListAsync();
@@ -244,12 +285,69 @@ public static class AlbumEndpoints
                 ReleaseDate = a.ReleaseDate
             }).ToList();
 
+            // Populate multi-valued tag arrays
+            foreach (var album in albumsData.Zip(albums, (a, dto) => new { Album = a, Dto = dto }))
+            {
+                PopulateMultiValuedTags(album.Album, album.Dto);
+            }
+
             return Results.Ok(new { data = albums });
         })
         .WithName("GetRecentAlbums")
         .WithOpenApi()
         .WithSummary("Get recently added albums")
         .WithDescription("Returns recently added albums");
+    }
+
+    /// <summary>
+    /// Populates multi-valued tag arrays (ArtistIds, ArtistNames, Genres) in an AlbumDto from an Album entity.
+    /// Ensures primary artist/genre (matching Album.ArtistId and Album.Genre) appears first in arrays.
+    /// </summary>
+    private static void PopulateMultiValuedTags(Album album, AlbumDto dto)
+    {
+        // Populate artist arrays: Primary first (matching Album.ArtistId), then others alphabetically
+        var primaryArtist = album.AlbumArtists
+            .FirstOrDefault(aa => aa.ArtistId == album.ArtistId)?.Artist;
+        var otherArtists = album.AlbumArtists
+            .Where(aa => aa.ArtistId != album.ArtistId)
+            .Select(aa => aa.Artist)
+            .OrderBy(a => a.Name)
+            .ToList();
+
+        var allArtists = primaryArtist != null
+            ? new[] { primaryArtist }.Concat(otherArtists).ToList()
+            : otherArtists;
+
+        dto.ArtistIds = allArtists.Select(a => a.Id).ToArray();
+        dto.ArtistNames = allArtists.Select(a => a.Name).ToArray();
+
+        // If no artists in many-to-many relationship, fallback to single-value field
+        if (dto.ArtistIds.Length == 0 && !string.IsNullOrEmpty(album.ArtistId))
+        {
+            dto.ArtistIds = new[] { album.ArtistId };
+            dto.ArtistNames = new[] { album.Artist?.Name ?? string.Empty };
+        }
+
+        // Populate genre arrays: Primary first (matching Album.Genre name), then others alphabetically
+        var primaryGenre = album.AlbumGenres
+            .FirstOrDefault(ag => ag.Genre.Name == album.Genre)?.Genre;
+        var otherGenres = album.AlbumGenres
+            .Where(ag => ag.Genre.Name != album.Genre)
+            .Select(ag => ag.Genre)
+            .OrderBy(g => g.Name)
+            .ToList();
+
+        var allGenres = primaryGenre != null
+            ? new[] { primaryGenre }.Concat(otherGenres).ToList()
+            : otherGenres;
+
+        dto.Genres = allGenres.Select(g => g.Name).ToArray();
+
+        // If no genres in many-to-many relationship, fallback to single-value field
+        if (dto.Genres.Length == 0 && !string.IsNullOrEmpty(album.Genre))
+        {
+            dto.Genres = new[] { album.Genre };
+        }
     }
 
     private static string GetImageContentType(string filePath)

--- a/src/Audiarr.Api/Endpoints/AlbumEndpoints.cs
+++ b/src/Audiarr.Api/Endpoints/AlbumEndpoints.cs
@@ -80,6 +80,13 @@ public static class AlbumEndpoints
             var albumData = await db.Albums
                 .Include(a => a.Artist)
                 .Include(a => a.Tracks)
+                    .ThenInclude(t => t.Artist)
+                .Include(a => a.Tracks)
+                    .ThenInclude(t => t.TrackArtists)
+                        .ThenInclude(ta => ta.Artist)
+                .Include(a => a.Tracks)
+                    .ThenInclude(t => t.TrackGenres)
+                        .ThenInclude(tg => tg.Genre)
                 .Include(a => a.AlbumArtists)
                     .ThenInclude(aa => aa.Artist)
                 .Include(a => a.AlbumGenres)
@@ -91,28 +98,35 @@ public static class AlbumEndpoints
                 return Results.NotFound(new { error = "Album not found" });
 
             // Process the data in memory to avoid SQLite APPLY operation issues
-            var tracks = albumData.Tracks
-                .Select(t => new TrackDto
-                {
-                    Id = t.Id,
-                    Title = t.Title,
-                    ArtistId = t.ArtistId,
-                    ArtistName = albumData.Artist.Name,
-                    AlbumId = t.AlbumId,
-                    AlbumTitle = albumData.Title,
-                    TrackNumber = t.TrackNumber,
-                    DiscNumber = t.DiscNumber,
-                    DurationMs = t.DurationMs,
-                    Genre = t.Genre,
-                    Year = t.Year,
-                    FileSize = t.FileSize,
-                    Bitrate = t.Bitrate,
-                    Codec = t.Codec,
-                    FilePath = t.FilePath
-                })
+            var tracksData = albumData.Tracks
                 .OrderBy(t => t.DiscNumber)
                 .ThenBy(t => t.TrackNumber)
                 .ToList();
+
+            var tracks = tracksData.Select(t => new TrackDto
+            {
+                Id = t.Id,
+                Title = t.Title,
+                ArtistId = t.ArtistId,
+                ArtistName = t.Artist?.Name ?? string.Empty,
+                AlbumId = t.AlbumId,
+                AlbumTitle = albumData.Title,
+                TrackNumber = t.TrackNumber,
+                DiscNumber = t.DiscNumber,
+                DurationMs = t.DurationMs,
+                Genre = t.Genre,
+                Year = t.Year,
+                FileSize = t.FileSize,
+                Bitrate = t.Bitrate,
+                Codec = t.Codec,
+                FilePath = t.FilePath
+            }).ToList();
+
+            // Populate multi-valued tag arrays for tracks
+            foreach (var track in tracksData.Zip(tracks, (t, dto) => new { Track = t, Dto = dto }))
+            {
+                PopulateMultiValuedTags(track.Track, track.Dto);
+            }
 
             // Create AlbumDto and populate multi-valued tags
             var albumDto = new AlbumDto
@@ -348,6 +362,57 @@ public static class AlbumEndpoints
         if (dto.Genres.Length == 0 && !string.IsNullOrEmpty(dto.Genre))
         {
             dto.Genres = new[] { dto.Genre };
+        }
+    }
+
+    /// <summary>
+    /// Populates multi-valued tag arrays (ArtistIds, ArtistNames, Genres) in a TrackDto from a Track entity.
+    /// Ensures primary artist/genre (matching Track.ArtistId and Track.Genre) appears first in arrays.
+    /// </summary>
+    private static void PopulateMultiValuedTags(Track track, TrackDto dto)
+    {
+        // Populate artist arrays: Primary first (matching Track.ArtistId), then others alphabetically
+        var primaryArtist = track.TrackArtists
+            .FirstOrDefault(ta => ta.ArtistId == track.ArtistId)?.Artist;
+        var otherArtists = track.TrackArtists
+            .Where(ta => ta.ArtistId != track.ArtistId)
+            .Select(ta => ta.Artist)
+            .OrderBy(a => a.Name)
+            .ToList();
+
+        var allArtists = primaryArtist != null
+            ? new[] { primaryArtist }.Concat(otherArtists).ToList()
+            : otherArtists;
+
+        dto.ArtistIds = allArtists.Select(a => a.Id).ToArray();
+        dto.ArtistNames = allArtists.Select(a => a.Name).ToArray();
+
+        // If no artists in many-to-many relationship, fallback to single-value field
+        if (dto.ArtistIds.Length == 0 && !string.IsNullOrEmpty(track.ArtistId))
+        {
+            dto.ArtistIds = new[] { track.ArtistId };
+            dto.ArtistNames = new[] { track.Artist?.Name ?? string.Empty };
+        }
+
+        // Populate genre arrays: Primary first (matching Track.Genre name), then others alphabetically
+        var primaryGenre = track.TrackGenres
+            .FirstOrDefault(tg => tg.Genre.Name == track.Genre)?.Genre;
+        var otherGenres = track.TrackGenres
+            .Where(tg => tg.Genre.Name != track.Genre)
+            .Select(tg => tg.Genre)
+            .OrderBy(g => g.Name)
+            .ToList();
+
+        var allGenres = primaryGenre != null
+            ? new[] { primaryGenre }.Concat(otherGenres).ToList()
+            : otherGenres;
+
+        dto.Genres = allGenres.Select(g => g.Name).ToArray();
+
+        // If no genres in many-to-many relationship, fallback to single-value field
+        if (dto.Genres.Length == 0 && !string.IsNullOrEmpty(track.Genre))
+        {
+            dto.Genres = new[] { track.Genre };
         }
     }
 

--- a/src/Audiarr.Api/Endpoints/ArtistEndpoints.cs
+++ b/src/Audiarr.Api/Endpoints/ArtistEndpoints.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Audiarr.Data.Context;
 using Audiarr.Core.DTOs;
+using Audiarr.Core.Entities;
 
 namespace Audiarr.Api.Endpoints;
 
@@ -125,32 +126,46 @@ public static class ArtistEndpoints
             if (!artistExists)
                 return Results.NotFound(new { error = "Artist not found" });
 
-            var albums = await db.Albums
+            // Query albums where artist is primary OR appears in many-to-many relationship
+            var albumsData = await db.Albums
                 .Include(a => a.Artist)
                 .Include(a => a.Tracks)
-                .Where(a => a.ArtistId == id)
-                .Select(a => new AlbumDto
-                {
-                    Id = a.Id,
-                    Title = a.Title,
-                    ArtistId = a.ArtistId,
-                    ArtistName = a.Artist.Name,
-                    Year = a.Year,
-                    TrackCount = a.Tracks.Count(),
-                    Genre = a.Tracks.Select(t => t.Genre).FirstOrDefault(),
-                    CoverArtPath = a.CoverArtPath,
-                    ReleaseDate = a.ReleaseDate
-                })
+                .Include(a => a.AlbumArtists)
+                    .ThenInclude(aa => aa.Artist)
+                .Include(a => a.AlbumGenres)
+                    .ThenInclude(ag => ag.Genre)
+                .Where(a => a.ArtistId == id || a.AlbumArtists.Any(aa => aa.ArtistId == id))
+                .Distinct()
                 .OrderBy(a => a.Year)
                 .ThenBy(a => a.Title)
                 .ToListAsync();
+
+            // Map to DTOs
+            var albums = albumsData.Select(a => new AlbumDto
+            {
+                Id = a.Id,
+                Title = a.Title,
+                ArtistId = a.ArtistId,
+                ArtistName = a.Artist.Name,
+                Year = a.Year,
+                TrackCount = a.Tracks.Count,
+                Genre = a.Tracks.Select(t => t.Genre).FirstOrDefault(),
+                CoverArtPath = a.CoverArtPath,
+                ReleaseDate = a.ReleaseDate
+            }).ToList();
+
+            // Populate multi-valued tag arrays
+            foreach (var album in albumsData.Zip(albums, (a, dto) => new { Album = a, Dto = dto }))
+            {
+                PopulateMultiValuedTags(album.Album, album.Dto);
+            }
 
             return Results.Ok(new { data = albums });
         })
         .WithName("GetArtistAlbums")
         .WithOpenApi()
         .WithSummary("Get artist's albums")
-        .WithDescription("Returns all albums for a specific artist");
+        .WithDescription("Returns all albums for a specific artist, including albums where the artist appears as a primary or contributing artist");
 
         // Get artist's tracks
         group.MapGet("/{id}/tracks", async (string id, AudiarrContext db) =>
@@ -159,38 +174,154 @@ public static class ArtistEndpoints
             if (!artistExists)
                 return Results.NotFound(new { error = "Artist not found" });
 
-            var tracks = await db.Tracks
+            // Query tracks where artist is primary OR appears in many-to-many relationship
+            var tracksData = await db.Tracks
                 .Include(t => t.Artist)
                 .Include(t => t.Album)
-                .Where(t => t.ArtistId == id)
-                .Select(t => new TrackDto
-                {
-                    Id = t.Id,
-                    Title = t.Title,
-                    ArtistId = t.ArtistId,
-                    ArtistName = t.Artist.Name,
-                    AlbumId = t.AlbumId,
-                    AlbumTitle = t.Album.Title,
-                    TrackNumber = t.TrackNumber,
-                    DiscNumber = t.DiscNumber,
-                    DurationMs = t.DurationMs,
-                    Genre = t.Genre,
-                    Year = t.Year,
-                    FileSize = t.FileSize,
-                    Bitrate = t.Bitrate,
-                    Codec = t.Codec,
-                    FilePath = t.FilePath
-                })
-                .OrderBy(t => t.AlbumTitle)
+                .Include(t => t.TrackArtists)
+                    .ThenInclude(ta => ta.Artist)
+                .Include(t => t.TrackGenres)
+                    .ThenInclude(tg => tg.Genre)
+                .Where(t => t.ArtistId == id || t.TrackArtists.Any(ta => ta.ArtistId == id))
+                .Distinct()
+                .OrderBy(t => t.Album.Title)
                 .ThenBy(t => t.DiscNumber)
                 .ThenBy(t => t.TrackNumber)
                 .ToListAsync();
+
+            // Map to DTOs
+            var tracks = tracksData.Select(t => new TrackDto
+            {
+                Id = t.Id,
+                Title = t.Title,
+                ArtistId = t.ArtistId,
+                ArtistName = t.Artist.Name,
+                AlbumId = t.AlbumId,
+                AlbumTitle = t.Album.Title,
+                TrackNumber = t.TrackNumber,
+                DiscNumber = t.DiscNumber,
+                DurationMs = t.DurationMs,
+                Genre = t.Genre,
+                Year = t.Year,
+                FileSize = t.FileSize,
+                Bitrate = t.Bitrate,
+                Codec = t.Codec,
+                FilePath = t.FilePath
+            }).ToList();
+
+            // Populate multi-valued tag arrays
+            foreach (var track in tracksData.Zip(tracks, (t, dto) => new { Track = t, Dto = dto }))
+            {
+                PopulateMultiValuedTags(track.Track, track.Dto);
+            }
 
             return Results.Ok(new { data = tracks });
         })
         .WithName("GetArtistTracks")
         .WithOpenApi()
         .WithSummary("Get artist's tracks")
-        .WithDescription("Returns all tracks for a specific artist");
+        .WithDescription("Returns all tracks for a specific artist, including tracks where the artist appears as a primary or contributing artist");
+    }
+
+    /// <summary>
+    /// Populates multi-valued tag arrays (ArtistIds, ArtistNames, Genres) in an AlbumDto from an Album entity.
+    /// Ensures primary artist/genre (matching Album.ArtistId and Album.Genre) appears first in arrays.
+    /// </summary>
+    private static void PopulateMultiValuedTags(Album album, AlbumDto dto)
+    {
+        // Populate artist arrays: Primary first (matching Album.ArtistId), then others alphabetically
+        var primaryArtist = album.AlbumArtists
+            .FirstOrDefault(aa => aa.ArtistId == album.ArtistId)?.Artist;
+        var otherArtists = album.AlbumArtists
+            .Where(aa => aa.ArtistId != album.ArtistId)
+            .Select(aa => aa.Artist)
+            .OrderBy(a => a.Name)
+            .ToList();
+
+        var allArtists = primaryArtist != null
+            ? new[] { primaryArtist }.Concat(otherArtists).ToList()
+            : otherArtists;
+
+        dto.ArtistIds = allArtists.Select(a => a.Id).ToArray();
+        dto.ArtistNames = allArtists.Select(a => a.Name).ToArray();
+
+        // If no artists in many-to-many relationship, fallback to single-value field
+        if (dto.ArtistIds.Length == 0 && !string.IsNullOrEmpty(album.ArtistId))
+        {
+            dto.ArtistIds = new[] { album.ArtistId };
+            dto.ArtistNames = new[] { album.Artist?.Name ?? string.Empty };
+        }
+
+        // Populate genre arrays: Primary first (matching Album.Genre name), then others alphabetically
+        var primaryGenre = album.AlbumGenres
+            .FirstOrDefault(ag => ag.Genre.Name == album.Genre)?.Genre;
+        var otherGenres = album.AlbumGenres
+            .Where(ag => ag.Genre.Name != album.Genre)
+            .Select(ag => ag.Genre)
+            .OrderBy(g => g.Name)
+            .ToList();
+
+        var allGenres = primaryGenre != null
+            ? new[] { primaryGenre }.Concat(otherGenres).ToList()
+            : otherGenres;
+
+        dto.Genres = allGenres.Select(g => g.Name).ToArray();
+
+        // If no genres in many-to-many relationship, fallback to single-value field
+        if (dto.Genres.Length == 0 && !string.IsNullOrEmpty(album.Genre))
+        {
+            dto.Genres = new[] { album.Genre };
+        }
+    }
+
+    /// <summary>
+    /// Populates multi-valued tag arrays (ArtistIds, ArtistNames, Genres) in a TrackDto from a Track entity.
+    /// Ensures primary artist/genre (matching Track.ArtistId and Track.Genre) appears first in arrays.
+    /// </summary>
+    private static void PopulateMultiValuedTags(Track track, TrackDto dto)
+    {
+        // Populate artist arrays: Primary first (matching Track.ArtistId), then others alphabetically
+        var primaryArtist = track.TrackArtists
+            .FirstOrDefault(ta => ta.ArtistId == track.ArtistId)?.Artist;
+        var otherArtists = track.TrackArtists
+            .Where(ta => ta.ArtistId != track.ArtistId)
+            .Select(ta => ta.Artist)
+            .OrderBy(a => a.Name)
+            .ToList();
+
+        var allArtists = primaryArtist != null
+            ? new[] { primaryArtist }.Concat(otherArtists).ToList()
+            : otherArtists;
+
+        dto.ArtistIds = allArtists.Select(a => a.Id).ToArray();
+        dto.ArtistNames = allArtists.Select(a => a.Name).ToArray();
+
+        // If no artists in many-to-many relationship, fallback to single-value field
+        if (dto.ArtistIds.Length == 0 && !string.IsNullOrEmpty(track.ArtistId))
+        {
+            dto.ArtistIds = new[] { track.ArtistId };
+            dto.ArtistNames = new[] { track.Artist?.Name ?? string.Empty };
+        }
+
+        // Populate genre arrays: Primary first (matching Track.Genre name), then others alphabetically
+        var primaryGenre = track.TrackGenres
+            .FirstOrDefault(tg => tg.Genre.Name == track.Genre)?.Genre;
+        var otherGenres = track.TrackGenres
+            .Where(tg => tg.Genre.Name != track.Genre)
+            .Select(tg => tg.Genre)
+            .OrderBy(g => g.Name)
+            .ToList();
+
+        var allGenres = primaryGenre != null
+            ? new[] { primaryGenre }.Concat(otherGenres).ToList()
+            : otherGenres;
+
+        dto.Genres = allGenres.Select(g => g.Name).ToArray();
+
+        // If no genres in many-to-many relationship, fallback to single-value field
+        if (dto.Genres.Length == 0 && !string.IsNullOrEmpty(track.Genre))
+        {
+            dto.Genres = new[] { track.Genre };
+        }
     }
 }

--- a/src/Audiarr.Api/Endpoints/ArtistEndpoints.cs
+++ b/src/Audiarr.Api/Endpoints/ArtistEndpoints.cs
@@ -225,7 +225,7 @@ public static class ArtistEndpoints
 
     /// <summary>
     /// Populates multi-valued tag arrays (ArtistIds, ArtistNames, Genres) in an AlbumDto from an Album entity.
-    /// Ensures primary artist/genre (matching Album.ArtistId and Album.Genre) appears first in arrays.
+    /// Ensures primary artist/genre (matching Album.ArtistId and dto.Genre) appears first in arrays.
     /// </summary>
     private static void PopulateMultiValuedTags(Album album, AlbumDto dto)
     {
@@ -252,11 +252,12 @@ public static class ArtistEndpoints
             dto.ArtistNames = new[] { album.Artist?.Name ?? string.Empty };
         }
 
-        // Populate genre arrays: Primary first (matching Album.Genre name), then others alphabetically
+        // Populate genre arrays: Primary first (matching dto.Genre name), then others alphabetically
+        // Use dto.Genre (which is set from first track's genre) instead of album.Genre to ensure consistency
         var primaryGenre = album.AlbumGenres
-            .FirstOrDefault(ag => ag.Genre.Name == album.Genre)?.Genre;
+            .FirstOrDefault(ag => ag.Genre.Name == dto.Genre)?.Genre;
         var otherGenres = album.AlbumGenres
-            .Where(ag => ag.Genre.Name != album.Genre)
+            .Where(ag => ag.Genre.Name != dto.Genre)
             .Select(ag => ag.Genre)
             .OrderBy(g => g.Name)
             .ToList();
@@ -268,9 +269,9 @@ public static class ArtistEndpoints
         dto.Genres = allGenres.Select(g => g.Name).ToArray();
 
         // If no genres in many-to-many relationship, fallback to single-value field
-        if (dto.Genres.Length == 0 && !string.IsNullOrEmpty(album.Genre))
+        if (dto.Genres.Length == 0 && !string.IsNullOrEmpty(dto.Genre))
         {
-            dto.Genres = new[] { album.Genre };
+            dto.Genres = new[] { dto.Genre };
         }
     }
 

--- a/src/Audiarr.Api/Endpoints/ArtistEndpoints.cs
+++ b/src/Audiarr.Api/Endpoints/ArtistEndpoints.cs
@@ -245,11 +245,21 @@ public static class ArtistEndpoints
         dto.ArtistIds = allArtists.Select(a => a.Id).ToArray();
         dto.ArtistNames = allArtists.Select(a => a.Name).ToArray();
 
-        // If no artists in many-to-many relationship, fallback to single-value field
-        if (dto.ArtistIds.Length == 0 && !string.IsNullOrEmpty(album.ArtistId))
+        // Ensure primary artist from single-value field is included first, even if not in many-to-many relationship
+        if (!string.IsNullOrEmpty(album.ArtistId))
         {
-            dto.ArtistIds = new[] { album.ArtistId };
-            dto.ArtistNames = new[] { album.Artist?.Name ?? string.Empty };
+            if (dto.ArtistIds.Length == 0)
+            {
+                // No artists in many-to-many relationship, use single-value field
+                dto.ArtistIds = new[] { album.ArtistId };
+                dto.ArtistNames = new[] { album.Artist?.Name ?? string.Empty };
+            }
+            else if (!dto.ArtistIds.Contains(album.ArtistId))
+            {
+                // Primary artist exists but is not in many-to-many relationship, prepend it
+                dto.ArtistIds = new[] { album.ArtistId }.Concat(dto.ArtistIds).ToArray();
+                dto.ArtistNames = new[] { album.Artist?.Name ?? string.Empty }.Concat(dto.ArtistNames).ToArray();
+            }
         }
 
         // Populate genre arrays: Primary first (matching dto.Genre name), then others alphabetically
@@ -268,10 +278,19 @@ public static class ArtistEndpoints
 
         dto.Genres = allGenres.Select(g => g.Name).ToArray();
 
-        // If no genres in many-to-many relationship, fallback to single-value field
-        if (dto.Genres.Length == 0 && !string.IsNullOrEmpty(dto.Genre))
+        // Ensure primary genre from single-value field is included first, even if not in many-to-many relationship
+        if (!string.IsNullOrEmpty(dto.Genre))
         {
-            dto.Genres = new[] { dto.Genre };
+            if (dto.Genres.Length == 0)
+            {
+                // No genres in many-to-many relationship, use single-value field
+                dto.Genres = new[] { dto.Genre };
+            }
+            else if (!dto.Genres.Contains(dto.Genre))
+            {
+                // Primary genre exists but is not in many-to-many relationship, prepend it
+                dto.Genres = new[] { dto.Genre }.Concat(dto.Genres).ToArray();
+            }
         }
     }
 
@@ -297,11 +316,21 @@ public static class ArtistEndpoints
         dto.ArtistIds = allArtists.Select(a => a.Id).ToArray();
         dto.ArtistNames = allArtists.Select(a => a.Name).ToArray();
 
-        // If no artists in many-to-many relationship, fallback to single-value field
-        if (dto.ArtistIds.Length == 0 && !string.IsNullOrEmpty(track.ArtistId))
+        // Ensure primary artist from single-value field is included first, even if not in many-to-many relationship
+        if (!string.IsNullOrEmpty(track.ArtistId))
         {
-            dto.ArtistIds = new[] { track.ArtistId };
-            dto.ArtistNames = new[] { track.Artist?.Name ?? string.Empty };
+            if (dto.ArtistIds.Length == 0)
+            {
+                // No artists in many-to-many relationship, use single-value field
+                dto.ArtistIds = new[] { track.ArtistId };
+                dto.ArtistNames = new[] { track.Artist?.Name ?? string.Empty };
+            }
+            else if (!dto.ArtistIds.Contains(track.ArtistId))
+            {
+                // Primary artist exists but is not in many-to-many relationship, prepend it
+                dto.ArtistIds = new[] { track.ArtistId }.Concat(dto.ArtistIds).ToArray();
+                dto.ArtistNames = new[] { track.Artist?.Name ?? string.Empty }.Concat(dto.ArtistNames).ToArray();
+            }
         }
 
         // Populate genre arrays: Primary first (matching Track.Genre name), then others alphabetically
@@ -319,10 +348,19 @@ public static class ArtistEndpoints
 
         dto.Genres = allGenres.Select(g => g.Name).ToArray();
 
-        // If no genres in many-to-many relationship, fallback to single-value field
-        if (dto.Genres.Length == 0 && !string.IsNullOrEmpty(track.Genre))
+        // Ensure primary genre from single-value field is included first, even if not in many-to-many relationship
+        if (!string.IsNullOrEmpty(track.Genre))
         {
-            dto.Genres = new[] { track.Genre };
+            if (dto.Genres.Length == 0)
+            {
+                // No genres in many-to-many relationship, use single-value field
+                dto.Genres = new[] { track.Genre };
+            }
+            else if (!dto.Genres.Contains(track.Genre))
+            {
+                // Primary genre exists but is not in many-to-many relationship, prepend it
+                dto.Genres = new[] { track.Genre }.Concat(dto.Genres).ToArray();
+            }
         }
     }
 }

--- a/src/Audiarr.Api/Endpoints/SearchEndpoints.cs
+++ b/src/Audiarr.Api/Endpoints/SearchEndpoints.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using Audiarr.Data.Context;
 using Microsoft.AspNetCore.Mvc;
+using Audiarr.Core.DTOs;
+using Audiarr.Core.Entities;
 
 namespace Audiarr.Api.Endpoints;
 
@@ -35,16 +37,24 @@ public static class SearchEndpoints
                     a.Id,
                     a.Name,
                     Type = "artist",
-                    AlbumCount = db.Albums.Count(al => al.ArtistId == a.Id),
-                    TrackCount = db.Tracks.Count(t => t.ArtistId == a.Id)
+                    AlbumCount = db.Albums.Count(al => al.ArtistId == a.Id || al.AlbumArtists.Any(aa => aa.ArtistId == a.Id)),
+                    TrackCount = db.Tracks.Count(t => t.ArtistId == a.Id || t.TrackArtists.Any(ta => ta.ArtistId == a.Id))
                 })
                 .ToListAsync();
 
             // Search albums
             var albums = await db.Albums
                 .Include(a => a.Artist)
+                .Include(a => a.AlbumArtists)
+                    .ThenInclude(aa => aa.Artist)
+                .Include(a => a.AlbumGenres)
+                    .ThenInclude(ag => ag.Genre)
                 .Where(a => a.Title.ToLower().Contains(searchTerm) ||
-                           (a.TitleNormalized != null && a.TitleNormalized.Contains(searchTerm)))
+                           (a.TitleNormalized != null && a.TitleNormalized.Contains(searchTerm)) ||
+                           a.Artist.Name.ToLower().Contains(searchTerm) ||
+                           (a.Genre != null && a.Genre.ToLower().Contains(searchTerm)) ||
+                           a.AlbumArtists.Any(aa => aa.Artist.Name.ToLower().Contains(searchTerm)) ||
+                           a.AlbumGenres.Any(ag => ag.Genre.Name.ToLower().Contains(searchTerm)))
                 .OrderBy(a => a.Title.Length)
                 .ThenBy(a => a.Title)
                 .Take(maxResults)
@@ -65,7 +75,15 @@ public static class SearchEndpoints
             var tracks = await db.Tracks
                 .Include(t => t.Artist)
                 .Include(t => t.Album)
-                .Where(t => t.Title.ToLower().Contains(searchTerm))
+                .Include(t => t.TrackArtists)
+                    .ThenInclude(ta => ta.Artist)
+                .Include(t => t.TrackGenres)
+                    .ThenInclude(tg => tg.Genre)
+                .Where(t => t.Title.ToLower().Contains(searchTerm) ||
+                           t.Artist.Name.ToLower().Contains(searchTerm) ||
+                           (t.Genre != null && t.Genre.ToLower().Contains(searchTerm)) ||
+                           t.TrackArtists.Any(ta => ta.Artist.Name.ToLower().Contains(searchTerm)) ||
+                           t.TrackGenres.Any(tg => tg.Genre.Name.ToLower().Contains(searchTerm)))
                 .OrderBy(t => t.Title.Length)
                 .ThenBy(t => t.Title)
                 .Take(maxResults)
@@ -105,7 +123,14 @@ public static class SearchEndpoints
             [FromBody] AdvancedSearchRequest request,
             AudiarrContext db) =>
         {
-            var query = db.Tracks.Include(t => t.Artist).Include(t => t.Album).AsQueryable();
+            var query = db.Tracks
+                .Include(t => t.Artist)
+                .Include(t => t.Album)
+                .Include(t => t.TrackArtists)
+                    .ThenInclude(ta => ta.Artist)
+                .Include(t => t.TrackGenres)
+                    .ThenInclude(tg => tg.Genre)
+                .AsQueryable();
 
             // Apply filters
             if (!string.IsNullOrWhiteSpace(request.Title))
@@ -115,7 +140,11 @@ public static class SearchEndpoints
 
             if (!string.IsNullOrWhiteSpace(request.Artist))
             {
-                query = query.Where(t => t.Artist.Name.ToLower().Contains(request.Artist.ToLower()));
+                var artistLower = request.Artist.ToLower();
+                query = query.Where(t => 
+                    t.Artist.Name.ToLower().Contains(artistLower) ||
+                    t.TrackArtists.Any(ta => ta.Artist.Name.ToLower().Contains(artistLower))
+                );
             }
 
             if (!string.IsNullOrWhiteSpace(request.Album))
@@ -125,7 +154,11 @@ public static class SearchEndpoints
 
             if (!string.IsNullOrWhiteSpace(request.Genre))
             {
-                query = query.Where(t => t.Genre != null && t.Genre.ToLower().Contains(request.Genre.ToLower()));
+                var genreLower = request.Genre.ToLower();
+                query = query.Where(t => 
+                    (t.Genre != null && t.Genre.ToLower().Contains(genreLower)) ||
+                    t.TrackGenres.Any(tg => tg.Genre.Name.ToLower().Contains(genreLower))
+                );
             }
 
             if (request.YearFrom.HasValue)
@@ -159,26 +192,38 @@ public static class SearchEndpoints
             // Pagination
             var pageSize = request.PageSize ?? 50;
             var page = request.Page ?? 1;
-            var tracks = await query
+            
+            // Load full entities to populate multi-valued tags
+            var tracksData = await query
                 .Skip((page - 1) * pageSize)
                 .Take(pageSize)
-                .Select(t => new
-                {
-                    t.Id,
-                    t.Title,
-                    ArtistId = t.ArtistId,
-                    ArtistName = t.Artist.Name,
-                    AlbumId = t.AlbumId,
-                    AlbumTitle = t.Album != null ? t.Album.Title : null,
-                    t.Year,
-                    t.Genre,
-                    DurationMs = t.DurationMs,
-                    t.BitRate,
-                    t.TrackNumber,
-                    t.DiscNumber,
-                    t.FilePath
-                })
                 .ToListAsync();
+
+            // Map to DTOs and populate multi-valued tag arrays
+            var tracks = tracksData.Select(t => new TrackDto
+            {
+                Id = t.Id,
+                Title = t.Title,
+                ArtistId = t.ArtistId,
+                ArtistName = t.Artist.Name,
+                AlbumId = t.AlbumId,
+                AlbumTitle = t.Album != null ? t.Album.Title : null,
+                Year = t.Year,
+                Genre = t.Genre,
+                DurationMs = t.DurationMs,
+                Bitrate = t.Bitrate,
+                TrackNumber = t.TrackNumber,
+                DiscNumber = t.DiscNumber,
+                FilePath = t.FilePath,
+                FileSize = t.FileSize,
+                Codec = t.Codec
+            }).ToList();
+
+            // Populate multi-valued tag arrays
+            foreach (var track in tracksData.Zip(tracks, (t, dto) => new { Track = t, Dto = dto }))
+            {
+                PopulateMultiValuedTags(track.Track, track.Dto);
+            }
 
             return Results.Ok(new
             {
@@ -255,6 +300,57 @@ public static class SearchEndpoints
         .WithOpenApi()
         .WithSummary("Get search suggestions")
         .WithDescription("Returns autocomplete suggestions based on partial search query");
+    }
+
+    /// <summary>
+    /// Populates multi-valued tag arrays (ArtistIds, ArtistNames, Genres) in a TrackDto from a Track entity.
+    /// Ensures primary artist/genre (matching Track.ArtistId and Track.Genre) appears first in arrays.
+    /// </summary>
+    private static void PopulateMultiValuedTags(Track track, TrackDto dto)
+    {
+        // Populate artist arrays: Primary first (matching Track.ArtistId), then others alphabetically
+        var primaryArtist = track.TrackArtists
+            .FirstOrDefault(ta => ta.ArtistId == track.ArtistId)?.Artist;
+        var otherArtists = track.TrackArtists
+            .Where(ta => ta.ArtistId != track.ArtistId)
+            .Select(ta => ta.Artist)
+            .OrderBy(a => a.Name)
+            .ToList();
+
+        var allArtists = primaryArtist != null
+            ? new[] { primaryArtist }.Concat(otherArtists).ToList()
+            : otherArtists;
+
+        dto.ArtistIds = allArtists.Select(a => a.Id).ToArray();
+        dto.ArtistNames = allArtists.Select(a => a.Name).ToArray();
+
+        // If no artists in many-to-many relationship, fallback to single-value field
+        if (dto.ArtistIds.Length == 0 && !string.IsNullOrEmpty(track.ArtistId))
+        {
+            dto.ArtistIds = new[] { track.ArtistId };
+            dto.ArtistNames = new[] { track.Artist?.Name ?? string.Empty };
+        }
+
+        // Populate genre arrays: Primary first (matching Track.Genre name), then others alphabetically
+        var primaryGenre = track.TrackGenres
+            .FirstOrDefault(tg => tg.Genre.Name == track.Genre)?.Genre;
+        var otherGenres = track.TrackGenres
+            .Where(tg => tg.Genre.Name != track.Genre)
+            .Select(tg => tg.Genre)
+            .OrderBy(g => g.Name)
+            .ToList();
+
+        var allGenres = primaryGenre != null
+            ? new[] { primaryGenre }.Concat(otherGenres).ToList()
+            : otherGenres;
+
+        dto.Genres = allGenres.Select(g => g.Name).ToArray();
+
+        // If no genres in many-to-many relationship, fallback to single-value field
+        if (dto.Genres.Length == 0 && !string.IsNullOrEmpty(track.Genre))
+        {
+            dto.Genres = new[] { track.Genre };
+        }
     }
 
     public class AdvancedSearchRequest

--- a/src/Audiarr.Api/Endpoints/SearchEndpoints.cs
+++ b/src/Audiarr.Api/Endpoints/SearchEndpoints.cs
@@ -324,11 +324,21 @@ public static class SearchEndpoints
         dto.ArtistIds = allArtists.Select(a => a.Id).ToArray();
         dto.ArtistNames = allArtists.Select(a => a.Name).ToArray();
 
-        // If no artists in many-to-many relationship, fallback to single-value field
-        if (dto.ArtistIds.Length == 0 && !string.IsNullOrEmpty(track.ArtistId))
+        // Ensure primary artist from single-value field is included first, even if not in many-to-many relationship
+        if (!string.IsNullOrEmpty(track.ArtistId))
         {
-            dto.ArtistIds = new[] { track.ArtistId };
-            dto.ArtistNames = new[] { track.Artist?.Name ?? string.Empty };
+            if (dto.ArtistIds.Length == 0)
+            {
+                // No artists in many-to-many relationship, use single-value field
+                dto.ArtistIds = new[] { track.ArtistId };
+                dto.ArtistNames = new[] { track.Artist?.Name ?? string.Empty };
+            }
+            else if (!dto.ArtistIds.Contains(track.ArtistId))
+            {
+                // Primary artist exists but is not in many-to-many relationship, prepend it
+                dto.ArtistIds = new[] { track.ArtistId }.Concat(dto.ArtistIds).ToArray();
+                dto.ArtistNames = new[] { track.Artist?.Name ?? string.Empty }.Concat(dto.ArtistNames).ToArray();
+            }
         }
 
         // Populate genre arrays: Primary first (matching Track.Genre name), then others alphabetically
@@ -346,10 +356,19 @@ public static class SearchEndpoints
 
         dto.Genres = allGenres.Select(g => g.Name).ToArray();
 
-        // If no genres in many-to-many relationship, fallback to single-value field
-        if (dto.Genres.Length == 0 && !string.IsNullOrEmpty(track.Genre))
+        // Ensure primary genre from single-value field is included first, even if not in many-to-many relationship
+        if (!string.IsNullOrEmpty(track.Genre))
         {
-            dto.Genres = new[] { track.Genre };
+            if (dto.Genres.Length == 0)
+            {
+                // No genres in many-to-many relationship, use single-value field
+                dto.Genres = new[] { track.Genre };
+            }
+            else if (!dto.Genres.Contains(track.Genre))
+            {
+                // Primary genre exists but is not in many-to-many relationship, prepend it
+                dto.Genres = new[] { track.Genre }.Concat(dto.Genres).ToArray();
+            }
         }
     }
 

--- a/src/Audiarr.Api/Endpoints/TrackEndpoints.cs
+++ b/src/Audiarr.Api/Endpoints/TrackEndpoints.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Audiarr.Data.Context;
 using Audiarr.Core.DTOs;
+using Audiarr.Core.Entities;
 
 namespace Audiarr.Api.Endpoints;
 
@@ -22,6 +23,10 @@ public static class TrackEndpoints
             var query = db.Tracks
                 .Include(t => t.Artist)
                 .Include(t => t.Album)
+                .Include(t => t.TrackArtists)
+                    .ThenInclude(ta => ta.Artist)
+                .Include(t => t.TrackGenres)
+                    .ThenInclude(tg => tg.Genre)
                 .OrderBy(t => t.Artist.SortName ?? t.Artist.Name)
                 .ThenBy(t => t.Album.Year)
                 .ThenBy(t => t.Album.Title)
@@ -30,28 +35,37 @@ public static class TrackEndpoints
 
             var total = await query.CountAsync();
 
-            var tracks = await query
+            // Load full entities to populate multi-valued tags
+            var tracksData = await query
                 .Skip((page - 1) * limit)
                 .Take(limit)
-                .Select(t => new TrackDto
-                {
-                    Id = t.Id,
-                    Title = t.Title,
-                    ArtistId = t.ArtistId,
-                    ArtistName = t.Artist.Name,
-                    AlbumId = t.AlbumId,
-                    AlbumTitle = t.Album.Title,
-                    TrackNumber = t.TrackNumber,
-                    DiscNumber = t.DiscNumber,
-                    DurationMs = t.DurationMs,
-                    Genre = t.Genre,
-                    Year = t.Year,
-                    FileSize = t.FileSize,
-                    Bitrate = t.Bitrate,
-                    Codec = t.Codec,
-                    FilePath = t.FilePath
-                })
                 .ToListAsync();
+
+            // Map to DTOs and populate arrays
+            var tracks = tracksData.Select(t => new TrackDto
+            {
+                Id = t.Id,
+                Title = t.Title,
+                ArtistId = t.ArtistId,
+                ArtistName = t.Artist.Name,
+                AlbumId = t.AlbumId,
+                AlbumTitle = t.Album.Title,
+                TrackNumber = t.TrackNumber,
+                DiscNumber = t.DiscNumber,
+                DurationMs = t.DurationMs,
+                Genre = t.Genre,
+                Year = t.Year,
+                FileSize = t.FileSize,
+                Bitrate = t.Bitrate,
+                Codec = t.Codec,
+                FilePath = t.FilePath
+            }).ToList();
+
+            // Populate multi-valued tag arrays
+            foreach (var track in tracksData.Zip(tracks, (t, dto) => new { Track = t, Dto = dto }))
+            {
+                PopulateMultiValuedTags(track.Track, track.Dto);
+            }
 
             return Results.Ok(new
             {
@@ -73,38 +87,71 @@ public static class TrackEndpoints
             var track = await db.Tracks
                 .Include(t => t.Artist)
                 .Include(t => t.Album)
+                .Include(t => t.TrackArtists)
+                    .ThenInclude(ta => ta.Artist)
+                .Include(t => t.TrackGenres)
+                    .ThenInclude(tg => tg.Genre)
                 .Where(t => t.Id == id)
-                .Select(t => new
-                {
-                    Id = t.Id,
-                    Title = t.Title,
-                    ArtistId = t.ArtistId,
-                    ArtistName = t.Artist.Name,
-                    AlbumId = t.AlbumId,
-                    AlbumTitle = t.Album.Title,
-                    TrackNumber = t.TrackNumber,
-                    DiscNumber = t.DiscNumber,
-                    DurationMs = t.DurationMs,
-                    Genre = t.Genre,
-                    Year = t.Year,
-                    FileSize = t.FileSize,
-                    Bitrate = t.Bitrate,
-                    Codec = t.Codec,
-                    SampleRate = t.SampleRate,
-                    Channels = t.Channels,
-                    FilePath = t.FilePath,
-                    FileHash = t.FileHash,
-                    AddedDate = t.AddedDate,
-                    ModifiedDate = t.ModifiedDate,
-                    PlayCount = t.PlayCount,
-                    LastPlayedDate = t.LastPlayedDate
-                })
                 .FirstOrDefaultAsync();
 
             if (track == null)
                 return Results.NotFound(new { error = "Track not found" });
 
-            return Results.Ok(track);
+            var dto = new TrackDto
+            {
+                Id = track.Id,
+                Title = track.Title,
+                ArtistId = track.ArtistId,
+                ArtistName = track.Artist.Name,
+                AlbumId = track.AlbumId,
+                AlbumTitle = track.Album.Title,
+                TrackNumber = track.TrackNumber,
+                DiscNumber = track.DiscNumber,
+                DurationMs = track.DurationMs,
+                Genre = track.Genre,
+                Year = track.Year,
+                FileSize = track.FileSize,
+                Bitrate = track.Bitrate,
+                Codec = track.Codec,
+                FilePath = track.FilePath
+            };
+
+            PopulateMultiValuedTags(track, dto);
+
+            // Return extended response with additional fields for backward compatibility
+            var result = new
+            {
+                dto.Id,
+                dto.Title,
+                dto.ArtistId,
+                dto.ArtistName,
+                dto.AlbumId,
+                dto.AlbumTitle,
+                dto.TrackNumber,
+                dto.DiscNumber,
+                dto.DurationMs,
+                dto.Genre,
+                dto.Year,
+                dto.FileSize,
+                dto.Bitrate,
+                dto.Codec,
+                SampleRate = track.SampleRate,
+                Channels = track.Channels,
+                FilePath = dto.FilePath,
+                FileHash = track.FileHash,
+                AddedDate = track.AddedDate,
+                ModifiedDate = track.ModifiedDate,
+                PlayCount = track.PlayCount,
+                LastPlayedDate = track.LastPlayedDate,
+                // Multi-valued tag arrays
+                dto.ArtistIds,
+                dto.ArtistNames,
+                dto.Genres,
+                dto.PrimaryArtistId,
+                dto.PrimaryArtistName
+            };
+
+            return Results.Ok(result);
         })
         .WithName("GetTrackById")
         .WithOpenApi()
@@ -152,31 +199,42 @@ public static class TrackEndpoints
         {
             if (limit < 1 || limit > 100) limit = 20;
 
-            var tracks = await db.Tracks
+            var tracksData = await db.Tracks
                 .Include(t => t.Artist)
                 .Include(t => t.Album)
+                .Include(t => t.TrackArtists)
+                    .ThenInclude(ta => ta.Artist)
+                .Include(t => t.TrackGenres)
+                    .ThenInclude(tg => tg.Genre)
                 .Where(t => t.LastPlayedDate != null)
                 .OrderByDescending(t => t.LastPlayedDate)
                 .Take(limit)
-                .Select(t => new TrackDto
-                {
-                    Id = t.Id,
-                    Title = t.Title,
-                    ArtistId = t.ArtistId,
-                    ArtistName = t.Artist.Name,
-                    AlbumId = t.AlbumId,
-                    AlbumTitle = t.Album.Title,
-                    TrackNumber = t.TrackNumber,
-                    DiscNumber = t.DiscNumber,
-                    DurationMs = t.DurationMs,
-                    Genre = t.Genre,
-                    Year = t.Year,
-                    FileSize = t.FileSize,
-                    Bitrate = t.Bitrate,
-                    Codec = t.Codec,
-                    FilePath = t.FilePath
-                })
                 .ToListAsync();
+
+            var tracks = tracksData.Select(t => new TrackDto
+            {
+                Id = t.Id,
+                Title = t.Title,
+                ArtistId = t.ArtistId,
+                ArtistName = t.Artist.Name,
+                AlbumId = t.AlbumId,
+                AlbumTitle = t.Album.Title,
+                TrackNumber = t.TrackNumber,
+                DiscNumber = t.DiscNumber,
+                DurationMs = t.DurationMs,
+                Genre = t.Genre,
+                Year = t.Year,
+                FileSize = t.FileSize,
+                Bitrate = t.Bitrate,
+                Codec = t.Codec,
+                FilePath = t.FilePath
+            }).ToList();
+
+            // Populate multi-valued tag arrays
+            foreach (var track in tracksData.Zip(tracks, (t, dto) => new { Track = t, Dto = dto }))
+            {
+                PopulateMultiValuedTags(track.Track, track.Dto);
+            }
 
             return Results.Ok(new { data = tracks });
         })
@@ -190,29 +248,42 @@ public static class TrackEndpoints
         {
             if (limit < 1 || limit > 100) limit = 50;
 
-            var tracks = await db.Tracks
+            var tracksData = await db.Tracks
                 .Include(t => t.Artist)
                 .Include(t => t.Album)
+                .Include(t => t.TrackArtists)
+                    .ThenInclude(ta => ta.Artist)
+                .Include(t => t.TrackGenres)
+                    .ThenInclude(tg => tg.Genre)
                 .Where(t => t.PlayCount > 0)
                 .OrderByDescending(t => t.PlayCount)
                 .Take(limit)
-                .Select(t => new
-                {
-                    Id = t.Id,
-                    Title = t.Title,
-                    ArtistId = t.ArtistId,
-                    ArtistName = t.Artist.Name,
-                    AlbumId = t.AlbumId,
-                    AlbumTitle = t.Album.Title,
-                    TrackNumber = t.TrackNumber,
-                    DiscNumber = t.DiscNumber,
-                    DurationMs = t.DurationMs,
-                    Genre = t.Genre,
-                    Year = t.Year,
-                    PlayCount = t.PlayCount,
-                    LastPlayedDate = t.LastPlayedDate
-                })
                 .ToListAsync();
+
+            var tracks = tracksData.Select(t => new TrackDto
+            {
+                Id = t.Id,
+                Title = t.Title,
+                ArtistId = t.ArtistId,
+                ArtistName = t.Artist.Name,
+                AlbumId = t.AlbumId,
+                AlbumTitle = t.Album.Title,
+                TrackNumber = t.TrackNumber,
+                DiscNumber = t.DiscNumber,
+                DurationMs = t.DurationMs,
+                Genre = t.Genre,
+                Year = t.Year,
+                FileSize = t.FileSize,
+                Bitrate = t.Bitrate,
+                Codec = t.Codec,
+                FilePath = t.FilePath
+            }).ToList();
+
+            // Populate multi-valued tag arrays
+            foreach (var track in tracksData.Zip(tracks, (t, dto) => new { Track = t, Dto = dto }))
+            {
+                PopulateMultiValuedTags(track.Track, track.Dto);
+            }
 
             return Results.Ok(new { data = tracks });
         })
@@ -243,6 +314,57 @@ public static class TrackEndpoints
         .WithOpenApi()
         .WithSummary("Update track play count")
         .WithDescription("Increments the play count and updates last played date");
+    }
+
+    /// <summary>
+    /// Populates multi-valued tag arrays (ArtistIds, ArtistNames, Genres) in a TrackDto from a Track entity.
+    /// Ensures primary artist/genre (matching Track.ArtistId and Track.Genre) appears first in arrays.
+    /// </summary>
+    private static void PopulateMultiValuedTags(Track track, TrackDto dto)
+    {
+        // Populate artist arrays: Primary first (matching Track.ArtistId), then others alphabetically
+        var primaryArtist = track.TrackArtists
+            .FirstOrDefault(ta => ta.ArtistId == track.ArtistId)?.Artist;
+        var otherArtists = track.TrackArtists
+            .Where(ta => ta.ArtistId != track.ArtistId)
+            .Select(ta => ta.Artist)
+            .OrderBy(a => a.Name)
+            .ToList();
+
+        var allArtists = primaryArtist != null
+            ? new[] { primaryArtist }.Concat(otherArtists).ToList()
+            : otherArtists;
+
+        dto.ArtistIds = allArtists.Select(a => a.Id).ToArray();
+        dto.ArtistNames = allArtists.Select(a => a.Name).ToArray();
+
+        // If no artists in many-to-many relationship, fallback to single-value field
+        if (dto.ArtistIds.Length == 0 && !string.IsNullOrEmpty(track.ArtistId))
+        {
+            dto.ArtistIds = new[] { track.ArtistId };
+            dto.ArtistNames = new[] { track.Artist?.Name ?? string.Empty };
+        }
+
+        // Populate genre arrays: Primary first (matching Track.Genre name), then others alphabetically
+        var primaryGenre = track.TrackGenres
+            .FirstOrDefault(tg => tg.Genre.Name == track.Genre)?.Genre;
+        var otherGenres = track.TrackGenres
+            .Where(tg => tg.Genre.Name != track.Genre)
+            .Select(tg => tg.Genre)
+            .OrderBy(g => g.Name)
+            .ToList();
+
+        var allGenres = primaryGenre != null
+            ? new[] { primaryGenre }.Concat(otherGenres).ToList()
+            : otherGenres;
+
+        dto.Genres = allGenres.Select(g => g.Name).ToArray();
+
+        // If no genres in many-to-many relationship, fallback to single-value field
+        if (dto.Genres.Length == 0 && !string.IsNullOrEmpty(track.Genre))
+        {
+            dto.Genres = new[] { track.Genre };
+        }
     }
 
     private static string GetAudioContentType(string filePath)

--- a/src/Audiarr.Api/Endpoints/TrackEndpoints.cs
+++ b/src/Audiarr.Api/Endpoints/TrackEndpoints.cs
@@ -236,7 +236,35 @@ public static class TrackEndpoints
                 PopulateMultiValuedTags(track.Track, track.Dto);
             }
 
-            return Results.Ok(new { data = tracks });
+            // Create extended response with PlayCount and LastPlayedDate for backward compatibility
+            var result = tracksData.Zip(tracks, (t, dto) => new
+            {
+                dto.Id,
+                dto.Title,
+                dto.ArtistId,
+                dto.ArtistName,
+                dto.AlbumId,
+                dto.AlbumTitle,
+                dto.TrackNumber,
+                dto.DiscNumber,
+                dto.DurationMs,
+                dto.Genre,
+                dto.Year,
+                dto.FileSize,
+                dto.Bitrate,
+                dto.Codec,
+                dto.FilePath,
+                PlayCount = t.PlayCount,
+                LastPlayedDate = t.LastPlayedDate,
+                // Multi-valued tag arrays
+                dto.ArtistIds,
+                dto.ArtistNames,
+                dto.Genres,
+                dto.PrimaryArtistId,
+                dto.PrimaryArtistName
+            }).ToList();
+
+            return Results.Ok(new { data = result });
         })
         .WithName("GetRecentlyPlayedTracks")
         .WithOpenApi()
@@ -285,7 +313,35 @@ public static class TrackEndpoints
                 PopulateMultiValuedTags(track.Track, track.Dto);
             }
 
-            return Results.Ok(new { data = tracks });
+            // Create extended response with PlayCount and LastPlayedDate for backward compatibility
+            var result = tracksData.Zip(tracks, (t, dto) => new
+            {
+                dto.Id,
+                dto.Title,
+                dto.ArtistId,
+                dto.ArtistName,
+                dto.AlbumId,
+                dto.AlbumTitle,
+                dto.TrackNumber,
+                dto.DiscNumber,
+                dto.DurationMs,
+                dto.Genre,
+                dto.Year,
+                dto.FileSize,
+                dto.Bitrate,
+                dto.Codec,
+                dto.FilePath,
+                PlayCount = t.PlayCount,
+                LastPlayedDate = t.LastPlayedDate,
+                // Multi-valued tag arrays
+                dto.ArtistIds,
+                dto.ArtistNames,
+                dto.Genres,
+                dto.PrimaryArtistId,
+                dto.PrimaryArtistName
+            }).ToList();
+
+            return Results.Ok(new { data = result });
         })
         .WithName("GetPopularTracks")
         .WithOpenApi()

--- a/src/Audiarr.Api/Endpoints/TrackEndpoints.cs
+++ b/src/Audiarr.Api/Endpoints/TrackEndpoints.cs
@@ -394,11 +394,21 @@ public static class TrackEndpoints
         dto.ArtistIds = allArtists.Select(a => a.Id).ToArray();
         dto.ArtistNames = allArtists.Select(a => a.Name).ToArray();
 
-        // If no artists in many-to-many relationship, fallback to single-value field
-        if (dto.ArtistIds.Length == 0 && !string.IsNullOrEmpty(track.ArtistId))
+        // Ensure primary artist from single-value field is included first, even if not in many-to-many relationship
+        if (!string.IsNullOrEmpty(track.ArtistId))
         {
-            dto.ArtistIds = new[] { track.ArtistId };
-            dto.ArtistNames = new[] { track.Artist?.Name ?? string.Empty };
+            if (dto.ArtistIds.Length == 0)
+            {
+                // No artists in many-to-many relationship, use single-value field
+                dto.ArtistIds = new[] { track.ArtistId };
+                dto.ArtistNames = new[] { track.Artist?.Name ?? string.Empty };
+            }
+            else if (!dto.ArtistIds.Contains(track.ArtistId))
+            {
+                // Primary artist exists but is not in many-to-many relationship, prepend it
+                dto.ArtistIds = new[] { track.ArtistId }.Concat(dto.ArtistIds).ToArray();
+                dto.ArtistNames = new[] { track.Artist?.Name ?? string.Empty }.Concat(dto.ArtistNames).ToArray();
+            }
         }
 
         // Populate genre arrays: Primary first (matching Track.Genre name), then others alphabetically
@@ -416,10 +426,19 @@ public static class TrackEndpoints
 
         dto.Genres = allGenres.Select(g => g.Name).ToArray();
 
-        // If no genres in many-to-many relationship, fallback to single-value field
-        if (dto.Genres.Length == 0 && !string.IsNullOrEmpty(track.Genre))
+        // Ensure primary genre from single-value field is included first, even if not in many-to-many relationship
+        if (!string.IsNullOrEmpty(track.Genre))
         {
-            dto.Genres = new[] { track.Genre };
+            if (dto.Genres.Length == 0)
+            {
+                // No genres in many-to-many relationship, use single-value field
+                dto.Genres = new[] { track.Genre };
+            }
+            else if (!dto.Genres.Contains(track.Genre))
+            {
+                // Primary genre exists but is not in many-to-many relationship, prepend it
+                dto.Genres = new[] { track.Genre }.Concat(dto.Genres).ToArray();
+            }
         }
     }
 

--- a/src/Audiarr.Core/DTOs/AlbumDto.cs
+++ b/src/Audiarr.Core/DTOs/AlbumDto.cs
@@ -1,14 +1,65 @@
 namespace Audiarr.Core.DTOs;
 
+/// <summary>
+/// Data transfer object for album information.
+/// Supports both single-valued and multi-valued artists and genres for backward compatibility.
+/// </summary>
 public class AlbumDto
 {
     public string Id { get; set; } = string.Empty;
     public string Title { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Primary artist ID (first artist in the album's artist list).
+    /// Maintained for backward compatibility. Use <see cref="ArtistIds"/> for all artists.
+    /// </summary>
     public string ArtistId { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Primary artist name (first artist in the album's artist list).
+    /// Maintained for backward compatibility. Use <see cref="ArtistNames"/> for all artists.
+    /// </summary>
     public string ArtistName { get; set; } = string.Empty;
+    
     public int? Year { get; set; }
     public int TrackCount { get; set; }
+    
+    /// <summary>
+    /// Primary genre (first genre in the album's genre list).
+    /// Maintained for backward compatibility. Use <see cref="Genres"/> for all genres.
+    /// </summary>
     public string? Genre { get; set; }
+    
     public string? CoverArtPath { get; set; }
     public DateTime? ReleaseDate { get; set; }
+    
+    /// <summary>
+    /// Array of all artist IDs associated with this album.
+    /// Empty array if no artists are associated. The first element corresponds to the primary artist (<see cref="ArtistId"/>).
+    /// </summary>
+    public string[] ArtistIds { get; set; } = Array.Empty<string>();
+    
+    /// <summary>
+    /// Array of all artist names associated with this album.
+    /// Empty array if no artists are associated. The first element corresponds to the primary artist (<see cref="ArtistName"/>).
+    /// </summary>
+    public string[] ArtistNames { get; set; } = Array.Empty<string>();
+    
+    /// <summary>
+    /// Array of all genre names associated with this album.
+    /// Empty array if no genres are associated. The first element corresponds to the primary genre (<see cref="Genre"/>).
+    /// </summary>
+    public string[] Genres { get; set; } = Array.Empty<string>();
+    
+    /// <summary>
+    /// Alias for <see cref="ArtistId"/>. Returns the primary artist ID for backward compatibility.
+    /// This property provides explicit naming to indicate it represents the primary (first) artist.
+    /// </summary>
+    public string PrimaryArtistId => ArtistId;
+    
+    /// <summary>
+    /// Alias for <see cref="ArtistName"/>. Returns the primary artist name for backward compatibility.
+    /// This property provides explicit naming to indicate it represents the primary (first) artist.
+    /// </summary>
+    public string PrimaryArtistName => ArtistName;
 }

--- a/src/Audiarr.Core/DTOs/TrackDto.cs
+++ b/src/Audiarr.Core/DTOs/TrackDto.cs
@@ -1,20 +1,71 @@
 namespace Audiarr.Core.DTOs;
 
+/// <summary>
+/// Data transfer object for track information.
+/// Supports both single-valued and multi-valued artists and genres for backward compatibility.
+/// </summary>
 public class TrackDto
 {
     public string Id { get; set; } = string.Empty;
     public string Title { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Primary artist ID (first artist in the track's artist list).
+    /// Maintained for backward compatibility. Use <see cref="ArtistIds"/> for all artists.
+    /// </summary>
     public string ArtistId { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Primary artist name (first artist in the track's artist list).
+    /// Maintained for backward compatibility. Use <see cref="ArtistNames"/> for all artists.
+    /// </summary>
     public string ArtistName { get; set; } = string.Empty;
+    
     public string AlbumId { get; set; } = string.Empty;
     public string AlbumTitle { get; set; } = string.Empty;
     public int? TrackNumber { get; set; }
     public int? DiscNumber { get; set; }
     public int DurationMs { get; set; }
+    
+    /// <summary>
+    /// Primary genre (first genre in the track's genre list).
+    /// Maintained for backward compatibility. Use <see cref="Genres"/> for all genres.
+    /// </summary>
     public string? Genre { get; set; }
+    
     public int? Year { get; set; }
     public long? FileSize { get; set; }
     public int? Bitrate { get; set; }
     public string? Codec { get; set; }
     public string FilePath { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Array of all artist IDs associated with this track.
+    /// Empty array if no artists are associated. The first element corresponds to the primary artist (<see cref="ArtistId"/>).
+    /// </summary>
+    public string[] ArtistIds { get; set; } = Array.Empty<string>();
+    
+    /// <summary>
+    /// Array of all artist names associated with this track.
+    /// Empty array if no artists are associated. The first element corresponds to the primary artist (<see cref="ArtistName"/>).
+    /// </summary>
+    public string[] ArtistNames { get; set; } = Array.Empty<string>();
+    
+    /// <summary>
+    /// Array of all genre names associated with this track.
+    /// Empty array if no genres are associated. The first element corresponds to the primary genre (<see cref="Genre"/>).
+    /// </summary>
+    public string[] Genres { get; set; } = Array.Empty<string>();
+    
+    /// <summary>
+    /// Alias for <see cref="ArtistId"/>. Returns the primary artist ID for backward compatibility.
+    /// This property provides explicit naming to indicate it represents the primary (first) artist.
+    /// </summary>
+    public string PrimaryArtistId => ArtistId;
+    
+    /// <summary>
+    /// Alias for <see cref="ArtistName"/>. Returns the primary artist name for backward compatibility.
+    /// This property provides explicit naming to indicate it represents the primary (first) artist.
+    /// </summary>
+    public string PrimaryArtistName => ArtistName;
 }


### PR DESCRIPTION
## Summary

This PR updates API endpoints and DTOs to return multi-valued artist and genre arrays, enabling clients to access all contributing artists and genres for tracks and albums. The implementation maintains full backward compatibility with existing single-valued fields while adding new array properties for enhanced functionality.

## Business Value

- **Enhanced API Responses**: Clients can now access complete artist and genre information via arrays
- **Better Discovery**: Search and filtering now work with all contributing artists/genres, not just primary
- **Backward Compatible**: Existing API consumers continue to work without changes
- **Industry Alignment**: Matches behavior of modern music servers like Gonic and Navidrome

## Changes

### DTO Updates

#### `AlbumDto`
- Added `ArtistIds: string[]` - Array of all artist IDs associated with the album
- Added `ArtistNames: string[]` - Array of all artist names associated with the album
- Added `Genres: string[]` - Array of all genre names associated with the album
- Added `PrimaryArtistId` and `PrimaryArtistName` properties (aliases for backward compatibility)
- Maintained existing `ArtistId`, `ArtistName`, and `Genre` properties for backward compatibility
- Added comprehensive XML documentation comments

#### `TrackDto`
- Added `ArtistIds: string[]` - Array of all artist IDs associated with the track
- Added `ArtistNames: string[]` - Array of all artist names associated with the track
- Added `Genres: string[]` - Array of all genre names associated with the track
- Added `PrimaryArtistId` and `PrimaryArtistName` properties (aliases for backward compatibility)
- Maintained existing `ArtistId`, `ArtistName`, and `Genre` properties for backward compatibility
- Added comprehensive XML documentation comments

### Endpoint Updates

#### Album Endpoints
- **`GET /api/v2/albums`**: 
  - Added eager loading of `AlbumArtists` and `AlbumGenres` navigation properties
  - Populates `ArtistIds`, `ArtistNames`, and `Genres` arrays in response
  - Maintains backward compatibility with single-valued fields
  
- **`GET /api/v2/albums/{id}`**:
  - Added eager loading of `AlbumArtists` and `AlbumGenres` navigation properties
  - Returns multi-valued tag arrays in response object
  - Primary artist/genre appears first in arrays for consistency

- **`GET /api/v2/albums/recent`**:
  - Added eager loading and array population
  - Consistent with other album endpoints

#### Track Endpoints
- **`GET /api/v2/tracks`**:
  - Added eager loading of `TrackArtists` and `TrackGenres` navigation properties
  - Populates multi-valued tag arrays for all tracks in paginated response
  - Optimized to load full entities before mapping to DTOs

- **`GET /api/v2/tracks/{id}`**:
  - Added eager loading of `TrackArtists` and `TrackGenres` navigation properties
  - Returns complete track information with multi-valued arrays

#### Artist Endpoints
- **`GET /api/v2/artists/{id}/albums`**:
  - Updated query to include albums where artist appears as primary OR contributing artist
  - Uses `.Where(a => a.ArtistId == id || a.AlbumArtists.Any(aa => aa.ArtistId == id))`
  - Added eager loading and array population for returned albums
  - Ensures no duplicate albums in results

- **`GET /api/v2/artists/{id}/tracks`**:
  - Updated query to include tracks where artist appears as primary OR contributing artist
  - Uses `.Where(t => t.ArtistId == id || t.TrackArtists.Any(ta => ta.ArtistId == id))`
  - Added eager loading and array population for returned tracks
  - Ensures no duplicate tracks in results

#### Search Endpoints
- **`GET /api/v2/search`**:
  - Updated artist count calculations to include many-to-many relationships
  - Album search now includes `AlbumArtists` and `AlbumGenres` in search criteria
  - Track search now includes `TrackArtists` and `TrackGenres` in search criteria
  - Search finds tracks/albums by any contributing artist or genre

- **`POST /api/v2/search/advanced`**:
  - Updated artist filter to check both primary artist and `TrackArtists` relationships
  - Updated genre filter to check both primary genre and `TrackGenres` relationships
  - Returns `TrackDto` objects with populated multi-valued tag arrays
  - Added eager loading of navigation properties for efficient queries

### Helper Methods

#### `PopulateMultiValuedTags()` (Album)
- Ensures primary artist (matching `Album.ArtistId`) appears first in arrays
- Other artists sorted alphabetically
- Primary genre (matching `Album.Genre`) appears first in arrays
- Other genres sorted alphabetically
- Fallback to single-valued fields when many-to-many relationships are empty

#### `PopulateMultiValuedTags()` (Track)
- Ensures primary artist (matching `Track.ArtistId`) appears first in arrays
- Other artists sorted alphabetically
- Primary genre (matching `Track.Genre`) appears first in arrays
- Other genres sorted alphabetically
- Fallback to single-valued fields when many-to-many relationships are empty

## Technical Details

### Query Optimization
- All endpoints use eager loading (`.Include()`) to prevent N+1 query problems
- Navigation properties loaded in single query: `TrackArtists.Artist`, `TrackGenres.Genre`, etc.
- Efficient `.Any()` checks for many-to-many relationship queries
- Proper use of `.Distinct()` where needed to prevent duplicates

### Array Population Strategy
1. Primary artist/genre (matching single-valued field) placed first
2. Other artists/genres sorted alphabetically
3. Empty arrays returned when no relationships exist
4. Fallback to single-valued fields ensures backward compatibility

### Backward Compatibility
- All existing single-valued properties (`ArtistId`, `ArtistName`, `Genre`) remain unchanged
- Existing API consumers continue to work without modification
- New array properties are additive, not breaking changes
- Primary artist/genre values match the first element in arrays

## Testing

- [x] All album endpoints return multi-valued tag arrays
- [x] All track endpoints return multi-valued tag arrays
- [x] Artist endpoints show all contributions (primary and contributing)
- [x] Search finds tracks/albums by any contributing artist/genre
- [x] Backward compatibility maintained (single-valued fields still present)
- [x] No duplicate results in artist album/track queries
- [x] Primary artist/genre appears first in arrays
- [x] Efficient queries (no N+1 problems)

## Related Stories

This PR completes the following stories from the Multi-Valued Tags Support epic:

### Phase 3: API Updates
- Update TrackDto for Multi-Valued Tags
- Update AlbumDto for Multi-Valued Tags
- Update Track Endpoints to Return Multi-Valued Tags
- Update Album Endpoints to Return Multi-Valued Tags
- Update Artist Endpoints for Multi-Valued Relationships
- Update Search Endpoints for Multi-Valued Tags

## Example API Response

### Before
```json
{
  "id": "track-123",
  "title": "Song Title",
  "artistId": "artist-1",
  "artistName": "Primary Artist",
  "genre": "Rock"
}
```

### After
```json
{
  "id": "track-123",
  "title": "Song Title",
  "artistId": "artist-1",
  "artistName": "Primary Artist",
  "genre": "Rock",
  "artistIds": ["artist-1", "artist-2"],
  "artistNames": ["Primary Artist", "Featured Artist"],
  "genres": ["Rock", "Alternative"],
  "primaryArtistId": "artist-1",
  "primaryArtistName": "Primary Artist"
}
```

## Breaking Changes

**None.** This PR maintains full backward compatibility. All existing single-valued fields remain unchanged, and new array properties are additive.

## Migration Notes

- No database migrations required (database changes were completed in previous PR)
- No configuration changes required
- Existing API consumers will continue to work without modification
- New clients can opt-in to use array properties for enhanced functionality

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds multi-valued tag support while preserving existing single-valued fields.
> 
> - Update `AlbumDto` and `TrackDto` to include `ArtistIds`, `ArtistNames`, `Genres` plus `PrimaryArtistId/Name` aliases (docs added)
> - Album/Track endpoints: eager-load `AlbumArtists/AlbumGenres` and `TrackArtists/TrackGenres`, map to DTOs, and populate arrays; extended responses include new arrays
> - Artist endpoints: return albums/tracks where artist is primary or contributing (`.Any(...)`, `.Distinct()`), with arrays populated
> - Search endpoints: include many-to-many artists/genres in criteria and counts; advanced search returns `TrackDto` with arrays
> - Add `PopulateMultiValuedTags` helpers (Album/Track) to order primary first, sort others, and fallback when relationships are empty
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b507c9fd47b001120fccca3d01e0dedcf192c093. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->